### PR TITLE
Fixes ID to non_null

### DIFF
--- a/packages/wordpress/uri-assets/class-schema.php
+++ b/packages/wordpress/uri-assets/class-schema.php
@@ -86,7 +86,7 @@ class Schema {
                 'interfaces' => [ 'Node' ],
                 'fields' => [
                     'id' => [
-                        'type' => 'ID',
+                        'type' => [ 'non_null' => 'ID' ],
                         'description' => __( 'The global ID of the URI Assets object.', 'nextpress' ),
                     ],
                     'uri' => [


### PR DESCRIPTION
ID was not previously defined as non_null which was throwing an error: ```"message": "Interface field Node.id expects type ID! but UriAssets.id is type ID."```