### PR TITLE
fix: wordpress plugin fix and documentation added

### DIFF
--- a/.changeset/better-suits-take.md
+++ b/.changeset/better-suits-take.md
@@ -1,0 +1,14 @@
+---
+"@axistaylor/nextpress-wordpress": patch
+---
+
+Problem: WooCommerce block scripts weren't being included in assetsByUri query results.
+
+Root Cause: WPGraphQL WooCommerce adds a filter making WC()->is_rest_api_request() return true for GraphQL requests.  
+WooCommerce blocks check this in their render_callback() and skip enqueuing scripts when it returns true.
+
+Solution:
+
+- Added nextpress_pre_simulate_render and nextpress_post_simulate_render hooks in the Model class around the content rendering simulation
+- In Assets class, hooked into these to temporarily override the filter (making it return false) during simulation, then restore it afterward
+- Only activates when enable_custom_wc_scripts setting is enable

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,28 +1,57 @@
-# NextPress Documentation
+<!--
+title: "@axistaylor/nextpress"
+description: "A comprehensive toolkit for rendering WordPress Gutenberg content 1:1 in Next.js applications."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, Next.js, WordPress, Gutenberg, WPGraphQL, headless CMS, content rendering"
+-->
+
+# @axistaylor/nextpress
 
 A comprehensive toolkit for rendering WordPress Gutenberg content 1:1 in Next.js applications.
 
 ## Table of Contents
 
-### Getting Started
+### Guides
 - [Getting Started](./getting-started.md) - Installation, setup, and your first WordPress page
-
-### Components
-- [Content](./content.md) - Render WordPress HTML content with custom parsers
-- [HeadScripts](./head-scripts.md) - Load WordPress header scripts with dependency resolution
-- [BodyScripts](./body-scripts.md) - Load WordPress footer scripts
-- [RenderStylesheets](./render-stylesheets.md) - Load WordPress stylesheets with inline styles
-
-### Configuration
-- [withWCR](./with-wcr.md) - Next.js configuration wrapper
-- [proxyByWCR](./proxy-by-wcr.md) - Middleware proxy for WordPress APIs
-
-### Advanced
 - [Multi-WordPress Setup](./multi-wordpress.md) - Connect to multiple WordPress backends
+- [WordPress Plugin](./wordpress-plugin.md) - Companion plugin for enhanced functionality
 - [Troubleshooting](./troubleshooting.md) - Common issues and solutions
+
+### API Reference
+- [API Overview](./api/README.md) - Complete API reference
+- [Content](./api/content.md) - Render WordPress HTML content with custom parsers
+- [HeadScripts](./api/head-scripts.md) - Load WordPress header scripts with dependency resolution
+- [BodyScripts](./api/body-scripts.md) - Load WordPress footer scripts
+- [RenderStylesheets](./api/render-stylesheets.md) - Load WordPress stylesheets with inline styles
+- [withWCR](./api/with-wcr.md) - Next.js configuration wrapper
+- [proxyByWCR](./api/proxy-by-wcr.md) - Middleware proxy for WordPress APIs
 
 ## Quick Links
 
 - [npm package](https://www.npmjs.com/package/@axistaylor/nextpress)
 - [GitHub repository](https://github.com/axistaylor/nextpress)
 - [WordPress plugin](./wordpress-plugin.md)
+
+## Introduction
+
+NextPress bridges the gap between WordPress and Next.js, enabling you to render Gutenberg content with pixel-perfect accuracy in your React applications. It handles the complexities of WordPress scripts, styles, and block markup so you can focus on building your application.
+
+### Key Features
+
+- **1:1 Content Rendering**: Render WordPress Gutenberg blocks exactly as they appear on your WordPress site
+- **Script Management**: Load WordPress scripts with proper dependency resolution
+- **Style Handling**: Include WordPress stylesheets and inline styles seamlessly
+- **Multi-site Support**: Connect to multiple WordPress backends from a single Next.js application
+- **WordPress Plugin**: Companion plugin for enhanced functionality
+
+### How It Works
+
+NextPress provides a set of React components and Next.js utilities that work together to fetch and render WordPress content:
+
+1. **Content Component**: Parses and renders WordPress HTML content with custom element handling
+2. **HeadScripts/BodyScripts**: Manage WordPress JavaScript files with correct load order
+3. **RenderStylesheets**: Include WordPress CSS with inline style support
+4. **withWCR**: Next.js configuration wrapper for seamless integration
+5. **proxyByWCR**: Middleware proxy for secure WordPress API communication
+
+Get started by following the [Getting Started guide](./getting-started.md).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,45 @@
+<!--
+title: "NextPress API Reference"
+description: "Complete API reference for NextPress components, utilities, and configuration options."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, API reference, Content, HeadScripts, BodyScripts, withWCR, proxyByWCR"
+-->
+
+# API Reference
+
+Complete reference for all NextPress exports.
+
+## Components
+
+| Export | Description |
+|--------|-------------|
+| [Content](./content.md) | Render WordPress HTML content with custom parsers |
+| [HeadScripts](./head-scripts.md) | Load WordPress header scripts with dependency resolution |
+| [BodyScripts](./body-scripts.md) | Load WordPress footer scripts |
+| [RenderStylesheets](./render-stylesheets.md) | Load WordPress stylesheets with inline styles |
+
+## Configuration
+
+| Export | Description |
+|--------|-------------|
+| [withWCR](./with-wcr.md) | Next.js configuration wrapper |
+| [proxyByWCR](./proxy-by-wcr.md) | Middleware proxy for WordPress APIs |
+
+## Quick Import Reference
+
+```tsx
+// Components
+import { Content, HeadScripts, BodyScripts, RenderStylesheets } from '@axistaylor/nextpress';
+
+// Configuration (separate entry points)
+import { withWCR } from '@axistaylor/nextpress/withWCR';
+import { proxyByWCR } from '@axistaylor/nextpress/proxyByWCR';
+
+// Types
+import type { CustomParserCallback } from '@axistaylor/nextpress';
+```
+
+## Related
+
+- [Getting Started](../getting-started.md) - Installation and setup
+- [Multi-WordPress Setup](../multi-wordpress.md) - Multiple backend configuration

--- a/docs/api/body-scripts.md
+++ b/docs/api/body-scripts.md
@@ -1,3 +1,10 @@
+<!--
+title: "BodyScripts Component"
+description: "Render WordPress footer scripts with dependency resolution, loading strategies, and inline script support."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, BodyScripts, WordPress, scripts, footer scripts, Next.js"
+-->
+
 # BodyScripts
 
 The `BodyScripts` component renders WordPress footer scripts with proper dependency resolution, loading strategies, and inline script support.
@@ -155,4 +162,4 @@ import type { EnqueuedScript } from '@axistaylor/nextpress';
 
 - [HeadScripts](./head-scripts.md) - Header script loading and URI retrieval
 - [RenderStylesheets](./render-stylesheets.md) - Stylesheet loading
-- [Getting Started](./getting-started.md) - Initial setup
+- [Getting Started](../getting-started.md) - Initial setup

--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -1,3 +1,10 @@
+<!--
+title: "Content Component"
+description: "Render WordPress HTML content in React with automatic Gutenberg block handling and custom parsers."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, Content component, WordPress, Gutenberg, HTML rendering, React"
+-->
+
 # Content Component
 
 The `Content` component renders WordPress HTML content in React, automatically handling Gutenberg blocks, HTML entities, and table structures.
@@ -240,7 +247,7 @@ When using multiple WordPress backends, specify the instance:
 <Content content={content} instance="blog" />
 ```
 
-See [Multi-WordPress Setup](./multi-wordpress.md) for configuration details.
+See [Multi-WordPress Setup](../multi-wordpress.md) for configuration details.
 
 ## TypeScript
 
@@ -253,6 +260,6 @@ import type { HTMLReactParserProps } from 'html-react-parser';
 
 ## Related
 
-- [Getting Started](./getting-started.md) - Initial setup
+- [Getting Started](../getting-started.md) - Initial setup
 - [HeadScripts](./head-scripts.md) - Loading WordPress scripts
 - [RenderStylesheets](./render-stylesheets.md) - Loading WordPress styles

--- a/docs/api/head-scripts.md
+++ b/docs/api/head-scripts.md
@@ -1,3 +1,10 @@
+<!--
+title: "HeadScripts Component"
+description: "Render WordPress header scripts with dependency resolution, loading strategies, and inline script support."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, HeadScripts, WordPress, scripts, dependency resolution, Next.js"
+-->
+
 # HeadScripts
 
 The `HeadScripts` component renders WordPress header scripts with proper dependency resolution, loading strategies, and inline script support.
@@ -222,4 +229,4 @@ import type { EnqueuedScript } from '@axistaylor/nextpress';
 - [BodyScripts](./body-scripts.md) - Footer script loading
 - [RenderStylesheets](./render-stylesheets.md) - Stylesheet loading
 - [proxyByWCR](./proxy-by-wcr.md) - Proxy configuration
-- [Getting Started](./getting-started.md) - Initial setup
+- [Getting Started](../getting-started.md) - Initial setup

--- a/docs/api/proxy-by-wcr.md
+++ b/docs/api/proxy-by-wcr.md
@@ -1,3 +1,10 @@
+<!--
+title: "proxyByWCR Middleware"
+description: "Middleware function that proxies requests to WordPress backends for REST API, AJAX, WooCommerce, and asset requests."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, proxyByWCR, middleware, WordPress, proxy, REST API, Next.js"
+-->
+
 # proxyByWCR
 
 `proxyByWCR` is a middleware function that proxies requests to WordPress backends. It handles REST API calls, AJAX requests, WooCommerce endpoints, and asset requests.
@@ -248,5 +255,5 @@ Ensure Cart-Token handling is implemented (see WooCommerce section above).
 
 - [withWCR](./with-wcr.md) - Next.js configuration
 - [HeadScripts](./head-scripts.md) - URI retrieval in layouts
-- [Multi-WordPress Setup](./multi-wordpress.md) - Multiple backends
-- [Troubleshooting](./troubleshooting.md) - Common issues
+- [Multi-WordPress Setup](../multi-wordpress.md) - Multiple backends
+- [Troubleshooting](../troubleshooting.md) - Common issues

--- a/docs/api/render-stylesheets.md
+++ b/docs/api/render-stylesheets.md
@@ -1,3 +1,10 @@
+<!--
+title: "RenderStylesheets Component"
+description: "Render WordPress stylesheets with dependency ordering, inline styles, and media query support."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, RenderStylesheets, WordPress, CSS, stylesheets, Next.js"
+-->
+
 # RenderStylesheets
 
 The `RenderStylesheets` component renders WordPress stylesheets with proper dependency ordering, inline styles, and media query support.
@@ -166,4 +173,4 @@ import type { EnqueuedStylesheet } from '@axistaylor/nextpress';
 
 - [HeadScripts](./head-scripts.md) - Header script loading
 - [BodyScripts](./body-scripts.md) - Footer script loading
-- [Getting Started](./getting-started.md) - Initial setup
+- [Getting Started](../getting-started.md) - Initial setup

--- a/docs/api/with-wcr.md
+++ b/docs/api/with-wcr.md
@@ -1,3 +1,10 @@
+<!--
+title: "withWCR Configuration Wrapper"
+description: "Next.js configuration wrapper that sets up WordPress connection, API redirects, and environment variables."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, withWCR, Next.js config, WordPress, configuration, environment variables"
+-->
+
 # withWCR
 
 `withWCR` is a Next.js configuration wrapper that sets up WordPress connection, generates API redirects, and configures environment variables.
@@ -71,7 +78,7 @@ export default withWCR(nextConfig, {
 });
 ```
 
-See [Multi-WordPress Setup](./multi-wordpress.md) for complete documentation.
+See [Multi-WordPress Setup](../multi-wordpress.md) for complete documentation.
 
 ## What withWCR Does
 
@@ -188,5 +195,5 @@ export default withWCR(nextConfig, {
 ## Related
 
 - [proxyByWCR](./proxy-by-wcr.md) - Middleware proxy setup
-- [Multi-WordPress Setup](./multi-wordpress.md) - Multiple backends
-- [Getting Started](./getting-started.md) - Initial setup
+- [Multi-WordPress Setup](../multi-wordpress.md) - Multiple backends
+- [Getting Started](../getting-started.md) - Initial setup

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+<!--
+title: "Getting Started with NextPress"
+description: "Step-by-step guide to setting up NextPress for rendering WordPress content in your Next.js application."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, Next.js, WordPress, setup, installation, WPGraphQL, headless CMS"
+-->
+
 # Getting Started
 
 This guide walks you through setting up NextPress to render WordPress content in your Next.js application.

--- a/docs/multi-wordpress.md
+++ b/docs/multi-wordpress.md
@@ -1,3 +1,10 @@
+<!--
+title: "Multi-WordPress Setup"
+description: "Connect to multiple WordPress backends from a single Next.js application for microservices, multi-tenant, and migration scenarios."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, multi-WordPress, multiple backends, microservices, multi-tenant, Next.js"
+-->
+
 # Multi-WordPress Setup
 
 NextPress supports connecting to multiple WordPress backends from a single Next.js application. This is useful for:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,10 @@
+<!--
+title: "Troubleshooting"
+description: "Common issues and solutions when using NextPress for WordPress content rendering in Next.js."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, troubleshooting, debugging, issues, solutions, Next.js, WordPress"
+-->
+
 # Troubleshooting
 
 Common issues and solutions when using NextPress.

--- a/docs/wordpress-plugin.md
+++ b/docs/wordpress-plugin.md
@@ -1,3 +1,10 @@
+<!--
+title: "NextPress WordPress Plugin"
+description: "WordPress plugin that extends WPGraphQL to expose enqueued scripts and stylesheets for Next.js frontends."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, WordPress plugin, WPGraphQL, scripts, stylesheets, Next.js"
+-->
+
 # NextPress WordPress Plugin
 
 The NextPress WordPress plugin extends WPGraphQL to expose enqueued scripts and stylesheets, enabling your Next.js frontend to load WordPress assets correctly.

--- a/packages/wordpress/includes/class-assets.php
+++ b/packages/wordpress/includes/class-assets.php
@@ -40,6 +40,10 @@ class Assets {
 
 		// Transform WooCommerce return URL (order-received page) for headless
 		add_filter( 'woocommerce_get_return_url', array( $this, 'transform_return_url' ), 10, 2 );
+
+		// Allow WC block scripts to enqueue during asset simulation
+		add_action( 'nextpress_pre_simulate_render', array( $this, 'disable_wc_rest_api_filter_for_simulation' ) );
+		add_action( 'nextpress_post_simulate_render', array( $this, 'restore_wc_rest_api_filter_after_simulation' ) );
 	}
 
 	/**
@@ -446,5 +450,33 @@ class Assets {
 
 		// Return relative path (browser will use current origin)
 		return $path . $query;
+	}
+
+	public function disable_wc_rest_api_filter_for_simulation() {
+		$settings   = get_option( 'nextpress_headless_settings', array() );
+		$is_enabled = isset( $settings['enable_custom_wc_scripts'] )
+			&& $settings['enable_custom_wc_scripts'] === 'on';
+
+		if ( ! $is_enabled ) {
+			return;
+		}
+
+		remove_filter( 'woocommerce_is_rest_api_request', '__return_true' );
+		add_filter( 'woocommerce_is_rest_api_request', '__return_false', 999 );
+	}
+
+	public function restore_wc_rest_api_filter_after_simulation() {
+		$settings   = get_option( 'nextpress_headless_settings', array() );
+		$is_enabled = isset( $settings['enable_custom_wc_scripts'] )
+			&& $settings['enable_custom_wc_scripts'] === 'on';
+
+		if ( ! $is_enabled ) {
+			return;
+		}
+
+		remove_filter( 'woocommerce_is_rest_api_request', '__return_false', 999 );
+		if ( function_exists( 'is_graphql_http_request' ) && is_graphql_http_request() ) {
+			add_filter( 'woocommerce_is_rest_api_request', '__return_true' );
+		}
 	}
 }

--- a/packages/wordpress/includes/class-model.php
+++ b/packages/wordpress/includes/class-model.php
@@ -284,6 +284,8 @@ class Model extends Base {
 				'enqueuedScriptsQueue'     => function () {
 					global $wp_scripts;
 
+					do_action( 'nextpress_pre_simulate_render' );
+
 					// Simulate WP template rendering.
 					ob_start();
 					do_action( 'wp_head' );
@@ -298,6 +300,8 @@ class Model extends Base {
 					do_action( 'wp_footer' );
 					ob_get_clean();
 
+					do_action( 'nextpress_post_simulate_render' );
+
 					// Sort and organize the enqueued scripts.
 					$queue = $this->flatten_enqueued_assets_list( $wp_scripts->queue ?? [], $wp_scripts );
 
@@ -309,6 +313,8 @@ class Model extends Base {
 				},
 				'enqueuedStylesheetsQueue' => function () {
 					global $wp_styles;
+
+					do_action( 'nextpress_pre_simulate_render' );
 
 					// Simulate WP template rendering.
 					ob_start();
@@ -323,6 +329,8 @@ class Model extends Base {
 					do_action( 'get_sidebar', null, [] );
 					wp_footer();
 					ob_get_clean();
+
+					do_action( 'nextpress_post_simulate_render' );
 
 					// Sort and organize the enqueued stylesheets.
 					$queue = $this->flatten_enqueued_assets_list( $wp_styles->queue ?? [], $wp_styles );

--- a/scripts/sync-wp-version.ts
+++ b/scripts/sync-wp-version.ts
@@ -3,7 +3,7 @@
  * Run after `changeset version` to keep nextpress.php in sync.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 
 const ROOT_DIR = join(__dirname, '..');
@@ -29,3 +29,47 @@ pluginContent = pluginContent.replace(
 writeFileSync(pluginPath, pluginContent);
 
 console.log(`  ✓ packages/wordpress/nextpress.php updated to ${version}`);
+
+// Replace all `@since TDB` with the current version across WordPress plugin files
+const wpPluginDir = join(ROOT_DIR, 'packages/wordpress');
+
+function getPhpFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(dir);
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory() && !entry.startsWith('.') && entry !== 'vendor' && entry !== 'node_modules') {
+      files.push(...getPhpFiles(fullPath));
+    } else if (stat.isFile() && entry.endsWith('.php')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const phpFiles = getPhpFiles(wpPluginDir);
+let replacedCount = 0;
+
+for (const filePath of phpFiles) {
+  let content = readFileSync(filePath, 'utf-8');
+  const originalContent = content;
+
+  content = content.replace(/@since TDB/g, `@since ${version}`);
+
+  if (content !== originalContent) {
+    writeFileSync(filePath, content);
+    const relativePath = filePath.replace(ROOT_DIR + '/', '');
+    console.log(`  ✓ ${relativePath} - replaced @since TDB`);
+    replacedCount++;
+  }
+}
+
+if (replacedCount > 0) {
+  console.log(`  ✓ Replaced @since TDB in ${replacedCount} file(s)`);
+} else {
+  console.log(`  ✓ No @since TDB placeholders found`);
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->
**Problem:** WooCommerce block scripts weren't being included in `assetsByUri` query results.

**Root Cause:** WPGraphQL WooCommerce adds a filter making `WC()->is_rest_api_request()` return true for GraphQL requests.  
WooCommerce blocks check this in their `render_callback()` and skip enqueuing scripts when it returns true.

**Solution:**
- Added `nextpress_pre_simulate_render` and `nextpress_post_simulate_render` hooks in the Model class around the content rendering simulation
- In Assets class, hooked into these to temporarily override the filter (making it return false) during simulation, then restore it afterward
- Only activates when `enable_custom_wc_scripts` setting is enable

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`npm run test:unit`)
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] I have updated documentation if needed
- [ ] I have added a changeset if this change affects published packages (`npm run changeset`)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any additional context or notes for reviewers -->
