### PR TITLE
fix: fire synthetic page events on initial mount

### DIFF
--- a/.changeset/page-events-on-mount.md
+++ b/.changeset/page-events-on-mount.md
@@ -1,0 +1,10 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+Fire synthetic DOMContentLoaded/load events on initial mount so WordPress scripts initialize on first page load.
+
+- New `usePageEvents` hook and `firePageEvents` utility that dispatch synthetic `DOMContentLoaded`, `load`, and `nextpress:page-change` events
+- New `<PageEvents>` client component for apps not using AssetUpdater
+- `AssetUpdater` fires page events on initial mount (before skipping asset refresh) so WP scripts that listen for `DOMContentLoaded` can initialize — previously they only fired on client-side navigation
+- Export `PageEvents`, `usePageEvents`, and `firePageEvents` from `@axistaylor/nextpress/client`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,9 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
 
-          # Check if tag already exists
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+          # Check if tag already exists (fetch remote tags since CI may be a shallow clone)
+          git fetch --tags origin 2>/dev/null || true
+          if git tag -l "$TAG_NAME" | grep -q "^${TAG_NAME}$"; then
             echo "Tag $TAG_NAME already exists, skipping"
           else
             echo "Creating tag $TAG_NAME"

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,7 +2,7 @@
 title: "NextPress API Reference"
 description: "Complete API reference for NextPress components, utilities, and configuration options."
 author: "AxisTaylor, LLC"
-keywords: "NextPress, API reference, Content, GlobalStyles, HeadScripts, BodyScripts, AssetUpdater, withWCR, proxyByWCR"
+keywords: "NextPress, API reference, Content, GlobalStyles, HeadScripts, BodyScripts, WPScripts, ImportMap, AssetUpdater, PageEvents, withWCR, proxyByWCR"
 -->
 
 # API Reference
@@ -16,14 +16,23 @@ Complete reference for all NextPress exports.
 | [Content](./content.md) | Render WordPress HTML content with custom parsers (wraps output in `[data-rendered]`) |
 | [GlobalStyles](./global-styles.md) | Render the WordPress global stylesheet, custom CSS, and font faces (scoped to `[data-rendered]`) |
 | [Stylesheets](./stylesheets.md) | Load WordPress enqueued stylesheets with inline styles |
-| [HeadScripts](./head-scripts.md) | Load WordPress header scripts with dependency resolution |
-| [BodyScripts](./body-scripts.md) | Load WordPress footer scripts |
+| [HeadScripts](./head-scripts.md) | Head asset wrapper: GlobalStyles + ImportMap + header scripts |
+| [BodyScripts](./body-scripts.md) | Body asset wrapper: footer scripts |
+| [WPScripts](./wp-scripts.md) | Core script renderer (classic, deferred, async, ES module) |
+| [ImportMap](./import-map.md) | Script module import map (`@wordpress/interactivity`, etc.) |
 
 ## Client Components
 
 | Export | Description |
 |--------|-------------|
-| [AssetUpdater](./asset-updater.md) | Refresh server-rendered stylesheets, scripts, and global styles on client-side navigation |
+| [AssetUpdater](./asset-updater.md) | Refresh server-rendered assets on client-side navigation (includes page events) |
+| [PageEvents](./page-events.md) | Fire synthetic WordPress lifecycle events (standalone, for apps not using AssetUpdater) |
+
+## Hooks
+
+| Export | Description |
+|--------|-------------|
+| [`usePageEvents`](./page-events.md#usepageevents-hook) | Hook to fire synthetic DOMContentLoaded/load events on mount and pathname change |
 
 ## Configuration
 
@@ -42,10 +51,17 @@ import {
   Stylesheets,
   HeadScripts,
   BodyScripts,
+  WPScripts,
+  ImportMap,
 } from '@axistaylor/nextpress';
 
-// Client components
-import { AssetUpdater } from '@axistaylor/nextpress/client';
+// Client components & hooks
+import {
+  AssetUpdater,
+  PageEvents,
+  usePageEvents,
+  firePageEvents,
+} from '@axistaylor/nextpress/client';
 import type { AssetData } from '@axistaylor/nextpress/client';
 
 // Configuration (separate entry points)
@@ -53,7 +69,14 @@ import { withWCR } from '@axistaylor/nextpress/withWCR';
 import { proxyByWCR } from '@axistaylor/nextpress/proxyByWCR';
 
 // Types
-import type { CustomParserCallback, GlobalStylesType } from '@axistaylor/nextpress';
+import type {
+  CustomParserCallback,
+  GlobalStylesType,
+  EnqueuedScript,
+  EnqueuedStylesheet,
+  ScriptTypeEnum,
+  WPImport,
+} from '@axistaylor/nextpress';
 ```
 
 ## Related

--- a/docs/api/page-events.md
+++ b/docs/api/page-events.md
@@ -1,0 +1,139 @@
+<!--
+title: "Page Events"
+description: "Fire synthetic WordPress lifecycle events so scripts can initialize in a headless Next.js environment."
+author: "AxisTaylor, LLC"
+keywords: "NextPress, PageEvents, DOMContentLoaded, usePageEvents, WordPress scripts, headless, lifecycle events"
+-->
+
+# Page Events
+
+## The Problem
+
+WordPress frontend scripts commonly initialize by listening for `DOMContentLoaded`:
+
+```js
+document.addEventListener('DOMContentLoaded', () => {
+  // Find block elements and set up interactivity
+  document.querySelectorAll('.my-block').forEach(initBlock);
+});
+```
+
+In a traditional WordPress page, this works because scripts load with `defer` — they execute after the DOM is parsed but before `DOMContentLoaded` fires.
+
+In a Next.js headless environment, scripts loaded via `next/script` with `afterInteractive` (the strategy used for WordPress deferred scripts) execute **after** React hydration, which is **after** `DOMContentLoaded` has already fired. The scripts register their listener but the event never comes — and the blocks never initialize.
+
+## The Solution
+
+NextPress fires **synthetic page lifecycle events** after hydration so WordPress scripts get the signals they expect:
+
+- `DOMContentLoaded` on `document`
+- `load` on `window`
+- `nextpress:page-change` custom event on `document`
+
+These fire:
+1. **On initial mount** — so scripts that missed the real `DOMContentLoaded` can initialize
+2. **On client-side navigation** — so scripts can re-initialize for new page content
+
+## Using AssetUpdater (Recommended)
+
+If you're using [`AssetUpdater`](./asset-updater.md), page events are fired automatically — you don't need `PageEvents` or `usePageEvents`. AssetUpdater fires events on initial mount and after each asset refresh on navigation.
+
+```tsx
+// This is all you need — page events are built in
+<AssetUpdater fetchAssets={fetchAssetsAction} />
+```
+
+## PageEvents Component
+
+For apps that don't use AssetUpdater (e.g. static sites, or layouts where assets don't change between pages), use the `PageEvents` client component:
+
+```tsx
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { PageEvents } from '@axistaylor/nextpress/client';
+
+export function MyPageEvents() {
+  const pathname = usePathname();
+  return <PageEvents pathname={pathname} />;
+}
+```
+
+Then in your layout:
+
+```tsx
+<BodyScripts scripts={scripts} pathname={uri} />
+<MyPageEvents />
+```
+
+### Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `pathname` | `string` | Yes | Current page pathname — triggers events on change |
+
+## usePageEvents Hook
+
+For more control, use the `usePageEvents` hook directly in your own client component:
+
+```tsx
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { usePageEvents } from '@axistaylor/nextpress/client';
+
+export function MyComponent() {
+  const pathname = usePathname();
+  usePageEvents(pathname);
+
+  // Your component logic...
+  return <div>...</div>;
+}
+```
+
+The hook fires events:
+- On initial mount (via `queueMicrotask` so React hydration completes first)
+- On every `pathname` change
+
+## firePageEvents Utility
+
+For imperative use (e.g. after dynamically loading content):
+
+```ts
+import { firePageEvents } from '@axistaylor/nextpress/client';
+
+// After inserting new WordPress content into the DOM
+firePageEvents();
+```
+
+## Events Dispatched
+
+| Event | Target | Purpose |
+|-------|--------|---------|
+| `DOMContentLoaded` | `document` | Standard DOM event — most WP scripts listen for this |
+| `load` | `window` | Window load event — some scripts wait for full page load |
+| `nextpress:page-change` | `document` | NextPress-specific event for scripts that want to distinguish real page loads from synthetic re-fires |
+
+## Writing Compatible Scripts
+
+If you're authoring WordPress blocks that need to work in both traditional and headless environments, use the readyState pattern:
+
+```js
+function initMyBlock() {
+  document.querySelectorAll('.my-block').forEach(/* ... */);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMyBlock);
+} else {
+  initMyBlock();
+}
+```
+
+This works on traditional WordPress (where `defer` scripts run before `DOMContentLoaded`) AND on headless Next.js (where the script may load after `DOMContentLoaded` but NextPress will also re-fire it).
+
+## Related
+
+- [AssetUpdater](./asset-updater.md) — Includes page events automatically
+- [WPScripts](./wp-scripts.md) — How scripts are rendered in head/body
+- [HeadScripts](./head-scripts.md) — Head asset wrapper

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -3,6 +3,7 @@ import { EnqueuedScript, EnqueuedStylesheet, GlobalStylesType, ScriptLoadingGrou
 import { WPImport } from '@/ImportMap';
 import { scopeInlineStyles } from '@/utils/scopeStyles';
 import { transformAssetUrl } from '@/utils/url';
+import { firePageEvents } from '@/hooks/usePageEvents';
 import { joinScriptContent } from '@/utils/content';
 import { replaceProxyPlaceholders, processWcSettings } from '@/compatibility/woocommerce';
 
@@ -352,15 +353,6 @@ function updateImportMap(
   document.head.appendChild(el);
 }
 
-/**
- * Fires the standard page lifecycle events so WordPress-enqueued scripts
- * that listen for them can re-initialize after a client-side navigation.
- */
-function firePageEvents(): void {
-  document.dispatchEvent(new Event('DOMContentLoaded'));
-  window.dispatchEvent(new Event('load'));
-  document.dispatchEvent(new CustomEvent('nextpress:page-change'));
-}
 
 /**
  * Client component that refreshes NextPress server-rendered assets
@@ -384,6 +376,9 @@ export function AssetUpdater({
   useEffect(() => {
     if (!hasMounted.current) {
       hasMounted.current = true;
+      // Fire synthetic page events on initial mount so WordPress scripts
+      // that missed the real DOMContentLoaded can initialize.
+      firePageEvents();
       return;
     }
 

--- a/packages/js/src/PageEvents/PageEvents.tsx
+++ b/packages/js/src/PageEvents/PageEvents.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { usePageEvents } from '@/hooks/usePageEvents';
+
+export interface PageEventsProps {
+  pathname: string;
+}
+
+/**
+ * Client component that fires synthetic page lifecycle events
+ * (DOMContentLoaded, load) so WordPress scripts can initialize.
+ *
+ * Use this if you're NOT using AssetUpdater (which fires these events
+ * internally). Place it in your layout's <body> alongside your scripts.
+ *
+ * ```tsx
+ * <BodyScripts scripts={scripts} pathname={uri} />
+ * <PageEvents pathname={pathname} />
+ * ```
+ */
+export function PageEvents({ pathname }: PageEventsProps) {
+  usePageEvents(pathname);
+  return null;
+}

--- a/packages/js/src/PageEvents/index.ts
+++ b/packages/js/src/PageEvents/index.ts
@@ -1,0 +1,2 @@
+export { PageEvents } from './PageEvents';
+export type { PageEventsProps } from './PageEvents';

--- a/packages/js/src/hooks/usePageEvents.ts
+++ b/packages/js/src/hooks/usePageEvents.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Fires synthetic page lifecycle events that WordPress-enqueued scripts
+ * depend on (DOMContentLoaded, load, nextpress:page-change).
+ *
+ * On the initial mount, scripts loaded via next/script afterInteractive
+ * miss the real DOMContentLoaded because it fires before hydration
+ * completes. This hook re-dispatches the events so those scripts can
+ * initialize.
+ *
+ * On subsequent calls (e.g. client-side navigation), the events fire
+ * again so scripts can re-initialize for the new page content.
+ */
+export function usePageEvents(pathname: string): void {
+  const hasMounted = useRef(false);
+
+  useEffect(() => {
+    if (!hasMounted.current) {
+      // Initial mount — fire events after a microtask so React hydration
+      // has finished and the DOM matches the SSR content.
+      hasMounted.current = true;
+      queueMicrotask(() => {
+        firePageEvents();
+      });
+      return;
+    }
+
+    // Subsequent navigations — fire immediately (AssetUpdater calls this
+    // after it has finished inserting the new assets).
+    firePageEvents();
+  }, [pathname]);
+}
+
+/**
+ * Dispatches synthetic page lifecycle events:
+ * - `DOMContentLoaded` on document
+ * - `load` on window
+ * - `nextpress:page-change` custom event on document
+ */
+export function firePageEvents(): void {
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  window.dispatchEvent(new Event('load'));
+  document.dispatchEvent(new CustomEvent('nextpress:page-change'));
+}

--- a/packages/js/src/index.client.ts
+++ b/packages/js/src/index.client.ts
@@ -1,2 +1,4 @@
 export * from '@/types';
 export * from '@/AssetUpdater';
+export * from '@/PageEvents';
+export { usePageEvents, firePageEvents } from '@/hooks/usePageEvents';


### PR DESCRIPTION
## Summary

WordPress frontend scripts listen for `DOMContentLoaded` to initialize. In Next.js, scripts loaded with `afterInteractive` execute after `DOMContentLoaded` has already fired, so the blocks never initialize on first page load.

This PR adds synthetic page event dispatching on initial mount:

- **`usePageEvents` hook** + **`firePageEvents` utility** — dispatch synthetic `DOMContentLoaded`, `load`, and `nextpress:page-change` events
- **`<PageEvents>` client component** — standalone component for apps not using AssetUpdater
- **`AssetUpdater`** — now fires page events on initial mount (before skipping asset refresh), so WP scripts initialize on first load without duplicating inline functionality
- **Documentation** — new Page Events guide covering the DOMContentLoaded timing problem, compatible script patterns, and when to use PageEvents vs AssetUpdater
- **Release workflow fix** — `git fetch --tags` before checking tag existence (CI shallow clones)

## Test plan

- [x] Homepage blocks initialize on first load (no need to navigate away and back)
- [x] Client-side navigation still re-initializes blocks
- [x] AssetUpdater does NOT re-fetch/duplicate assets on mount
- [x] Unit tests pass
- [x] Build passes