### PR TITLE
fix: prevent inline style deduplication in Stylesheets component

### DIFF
--- a/.changeset/fix-inline-style-dedup.md
+++ b/.changeset/fix-inline-style-dedup.md
@@ -1,0 +1,9 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+Fix inline styles (before/after) being deduplicated by React
+
+The Stylesheets component used the same `href` value for both the `<link>` stylesheet and its inline `<style>` before/after tags. React deduplicates `<style>` elements with identical `href` values, causing inline styles registered via `wp_add_inline_style()` to silently disappear from the rendered HTML.
+
+Changed the `href` on inline `<Style>` tags to use `{handle}-before-inline` and `{handle}-after-inline` instead of reusing the parent stylesheet's URL, ensuring each element has a unique identity for React's deduplication logic.

--- a/README.md
+++ b/README.md
@@ -28,24 +28,7 @@ Components and utilities for rendering WordPress content in Next.js:
 
 ### [NextPress WordPress Plugin](./packages/wordpress) - WordPress Plugin
 
-Add the GitHub repository to your `composer.json`:
-
-```json
-{
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/AxisTaylor/nextpress.git"
-    }
-  ]
-}
-```
-
-Then require the package:
-
-```bash
-composer require axistaylor/nextpress:dev-main
-```
+Download the latest `nextpress.zip` from the [Releases page](https://github.com/AxisTaylor/nextpress/releases) and install it via **Plugins > Add New > Upload Plugin** in your WordPress admin.
 
 Extends WPGraphQL with queries for enqueued scripts and stylesheets.
 

--- a/packages/backend-4-examples/web/app/themes/custom-block-theme/functions.php
+++ b/packages/backend-4-examples/web/app/themes/custom-block-theme/functions.php
@@ -44,5 +44,12 @@ function custom_block_theme_styles() {
 		wp_get_theme()->get( 'Version' )
 	);
 	wp_enqueue_style( 'custom-block-theme-style' );
+
+	// Add inline CSS after the theme stylesheet for e2e testing
+	// of inline style rendering in the headless frontend.
+	wp_add_inline_style(
+		'custom-block-theme-style',
+		'.nextpress-inline-test { --inline-test: passed; color: green; }'
+	);
 }
 add_action( 'wp_enqueue_scripts', 'custom_block_theme_styles' );

--- a/packages/e2e-tests/tests/inline-styles.spec.ts
+++ b/packages/e2e-tests/tests/inline-styles.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Inline Styles Tests
+ *
+ * Validates that WordPress inline styles (wp_add_inline_style) registered
+ * as "after" scripts on enqueued stylesheets are rendered in the HTML
+ * output of the headless frontend.
+ *
+ * The custom-block-theme in backend-4-examples registers a test inline
+ * style on `custom-block-theme-style` with the class `.nextpress-inline-test`.
+ */
+
+test.describe('Inline Stylesheet Rendering', () => {
+  test('should render inline "after" styles in the HTML', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Find the inline style tag for the theme stylesheet's after content
+    const inlineStyle = page.locator('style[data-href="custom-block-theme-style-after-inline"]');
+    const count = await inlineStyle.count();
+
+    // If React uses data-href, check that. Otherwise check id.
+    if (count === 0) {
+      // React may render the href as data-href or the style may use the id attribute
+      const byId = page.locator('style#custom-block-theme-style-inline-css');
+      const idCount = await byId.count();
+
+      if (idCount === 0) {
+        // Search all style tags for the test class
+        const allStyles = await page.locator('style').evaluateAll((styles) =>
+          styles.map((s) => s.textContent || '')
+        );
+
+        const hasInlineTest = allStyles.some((content) =>
+          content.includes('.nextpress-inline-test')
+        );
+
+        expect(hasInlineTest).toBe(true);
+      } else {
+        const content = await byId.textContent();
+        expect(content).toContain('.nextpress-inline-test');
+      }
+    } else {
+      const content = await inlineStyle.textContent();
+      expect(content).toContain('.nextpress-inline-test');
+    }
+  });
+
+  test('inline "after" style should contain the expected CSS rule', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Get all style tag contents
+    const allStyleContents = await page.locator('style').evaluateAll((styles) =>
+      styles.map((s) => s.textContent || '')
+    );
+
+    // Find the one containing our test class
+    const testStyle = allStyleContents.find((content) =>
+      content.includes('.nextpress-inline-test')
+    );
+
+    expect(testStyle).toBeDefined();
+    expect(testStyle).toContain('--inline-test: passed');
+    expect(testStyle).toContain('color: green');
+  });
+
+  test('inline "after" style should not be deduplicated with its parent stylesheet', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // The parent stylesheet link should exist
+    const themeLink = page.locator('link[rel="stylesheet"][href*="custom-block-theme"]');
+    await expect(themeLink.first()).toBeAttached();
+
+    // AND the inline after style should also exist (not deduplicated)
+    const allStyleContents = await page.locator('style').evaluateAll((styles) =>
+      styles.map((s) => s.textContent || '')
+    );
+
+    const hasInlineTest = allStyleContents.some((content) =>
+      content.includes('.nextpress-inline-test')
+    );
+
+    expect(hasInlineTest).toBe(true);
+  });
+});

--- a/packages/js/src/Stylesheets/Stylesheets.tsx
+++ b/packages/js/src/Stylesheets/Stylesheets.tsx
@@ -62,7 +62,7 @@ export function Stylesheets({ stylesheets, instance = 'default', pathname: _path
         return (
           <Fragment key={handle}>
             {stylesheet.before && (
-              <Style id={`${handle}-before`} precedence="low" href={href || undefined}>
+              <Style id={`${handle}-before`} precedence="low" href={`${handle}-before-inline`}>
                 {scopeInlineStyles(stylesheet.before.join(''))}
               </Style>
             )}
@@ -70,7 +70,7 @@ export function Stylesheets({ stylesheets, instance = 'default', pathname: _path
               <Link rel="stylesheet" href={href} id={`${handle}-css`} precedence="medium" />
             )}
             {stylesheet.after && (
-              <Style id={`${handle}-inline-css`} precedence="high" href={href || undefined}>
+              <Style id={`${handle}-inline-css`} precedence="high" href={`${handle}-after-inline`}>
                 {scopeInlineStyles(stylesheet.after.join(''))}
               </Style>
             )}


### PR DESCRIPTION
## Summary

- Fixed inline `before`/`after` styles being silently dropped from rendered HTML due to React's `<style>` deduplication by `href`
- The `Stylesheets` component reused the parent stylesheet's `href` for inline `<style>` tags — React treated them as duplicates of the `<link>` element and only rendered one
- Changed inline style `href` values to `{handle}-before-inline` / `{handle}-after-inline` to ensure unique identities

## Test plan

- [x] Added e2e test (`inline-styles.spec.ts`) that verifies inline after styles render in the HTML
- [x] Added test fixture in `custom-block-theme/functions.php` via `wp_add_inline_style()`