### PR TITLE
fix(workflow): build WP plugin and trim source-only files before mirroring to dist repo

### DIFF
--- a/.github/workflows/deploy-wp-plugin-dist.yml
+++ b/.github/workflows/deploy-wp-plugin-dist.yml
@@ -21,11 +21,29 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
           tools: composer:v2
+
+      # Install at the repo root so the WP plugin's webpack bundle build can
+      # resolve devDependencies via the monorepo's hoisted node_modules.
+      - name: Install npm dependencies
+        run: npm ci
+
+      # Build the editor/runtime bundles webpack writes into the plugin's
+      # build/ output. Without this step the dist repo ships sources only and
+      # the plugin breaks on install.
+      - name: Build WordPress plugin bundles
+        working-directory: packages/wordpress
+        run: npm run build
 
       - name: Install runtime composer dependencies
         working-directory: packages/wordpress

--- a/packages/wordpress/.distignore
+++ b/packages/wordpress/.distignore
@@ -8,6 +8,7 @@
 /local
 /plugin-build
 /tests
+/assets/src
 /codeception.yml
 /composer.lock
 /docker-compose.yml
@@ -15,6 +16,8 @@
 /webpack.config.js
 /tsconfig.json
 /node_modules
+/package.json
+/package-lock.json
 /.distignore
 /.git
 /.github


### PR DESCRIPTION
## Summary

- Run `npm ci` at the repo root and `npm run build` in `packages/wordpress` inside `deploy-wp-plugin-dist.yml` before the composer install + rsync steps, so the plugin's editor/runtime bundles are compiled into `assets/dist/` before mirroring.
- Add `/package.json`, `/package-lock.json`, and `/assets/src` to `packages/wordpress/.distignore` so the dist repo only carries compiled output (`assets/dist/`) alongside PHP sources and runtime `vendor/`, not the JS manifests or the webpack source tree.

## Test plan

- [x] CI green.
- [ ] After merge and the next `wp-v*` tag, confirm the dist repo snapshot contains `assets/dist/` with the compiled bundle and does NOT contain `package.json`, `package-lock.json`, `node_modules/`, or `assets/src/`.