### PR TITLE
fix: match repository.url casing to GitHub for provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "nextjs",
     "wordpress-content"
   ],
-  "author": "Geoff Taylor <geoff@axistaylor.com>",
+  "author": "AxisTaylor, LLC <support@axistaylor.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/axistaylor/nextpress.git"
+    "url": "https://github.com/AxisTaylor/nextpress.git"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -16,5 +16,5 @@
     "test:codegen": "playwright codegen http://localhost:3000",
     "report": "playwright show-report"
   },
-  "author": "Geoff Taylor <support@axistaylor.com>"
+  "author": "AxisTaylor, LLC <support@axistaylor.com>"
 }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -11,9 +11,9 @@
     "woocommerce",
     "react"
   ],
-  "homepage": "https://github.com/axistaylor/nextpress",
+  "homepage": "https://github.com/AxisTaylor/nextpress",
   "bugs": {
-    "url": "https://github.com/axistaylor/nextpress/issues"
+    "url": "https://github.com/AxisTaylor/nextpress/issues"
   },
   "publishConfig": {
     "access": "public"
@@ -93,6 +93,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/axistaylor/nextpress.git"
+    "url": "https://github.com/AxisTaylor/nextpress.git"
   }
 }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -89,7 +89,7 @@
     "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit"
   },
-  "author": "AxisTaylor <support@axistaylor.com>",
+  "author": "AxisTaylor, LLC <support@axistaylor.com>",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/nextjs-example/package.json
+++ b/packages/nextjs-example/package.json
@@ -24,5 +24,5 @@
     "@tailwindcss/postcss": "^4.2.4",
     "typescript": "^6.0.3"
   },
-  "author": "AxisTaylor <support@axistaylor.com>"
+  "author": "AxisTaylor, LLC <support@axistaylor.com>"
 }

--- a/packages/wordpress/package.json
+++ b/packages/wordpress/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "private": true,
   "description": "A WPGraphQL extension. Adds the queries needed to render WP content on a 1:1 scale in a headless environment.",
-  "author": "Geoff Taylor",
+  "author": "AxisTaylor, LLC <support@axistaylor.com>",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "build": "webpack --mode production",


### PR DESCRIPTION
## Summary

- Update `packages/js/package.json` — `repository.url`, `homepage`, and `bugs.url` — from the lowercase `github.com/axistaylor/nextpress` form to the canonical `github.com/AxisTaylor/nextpress` form.
- No changeset on purpose. The package.json version on main is already at the pending `1.5.0` from the previous release PR merge; merging this PR lets the next workflow run take the publish path and ship that same `1.5.0` with a corrected `repository.url` so sigstore provenance validation passes.

The previous publish attempt failed with:
> `422 Unprocessable Entity - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/axistaylor/nextpress.git", expected to match "https://github.com/AxisTaylor/nextpress" from provenance`

GitHub Actions OIDC signs the provenance with the canonical repo path (`AxisTaylor/nextpress`); npm compares case-sensitively against the package.json URL after stripping the `git+` prefix and `.git` suffix.

## Test plan

- [ ] `changeset-status` is expected to fail since the JS package is modified without a changeset — merge with admin override.
- [ ] After merge, the next `release.yml` run takes the publish path, signs a new provenance bundle, and `@axistaylor/nextpress@1.5.0` reaches the npm registry.
- [ ] `wp-v<version>` tag step runs and triggers `deploy-wp-plugin-dist.yml`.