### PR TITLE
ci: fix deploy_plugin_dist clone for non-bare dist repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,17 +215,24 @@ jobs:
         run: |
           set -eux
 
-          # Bare-style checkout: clone the dist repo's metadata into
-          # $DIST_DIR/.git, then set GIT_WORK_TREE to the staged source
-          # bundle. Git commits whatever's in $SRC_DIR against the dist
-          # repo's index without copying files around. Mirrors the
-          # pattern xwp/stream uses to ship to xwp/stream-dist.
-          export GIT_DIR="$DIST_DIR/.git"
+          # Plain clone: the dist repo lands at $DIST_DIR with its
+          # metadata at $DIST_DIR/.git in the normal layout. The earlier
+          # GIT_DIR/GIT_WORK_TREE-split pattern (cloning into
+          # $DIST_DIR/.git directly) put metadata at $DIST_DIR/.git/.git
+          # so subsequent git commands looking at GIT_DIR=$DIST_DIR/.git
+          # errored with "fatal: not a git repository".
+          git clone --progress --verbose git@github.com:AxisTaylor/nextpress-wp-plugin-dist.git "$DIST_DIR"
+          cd "$DIST_DIR"
 
-          git clone --progress --verbose git@github.com:AxisTaylor/nextpress-wp-plugin-dist.git "$DIST_DIR/.git"
+          # Make sure main exists locally — branch is unborn on a freshly
+          # bootstrapped dist repo until the first push.
           git checkout -B main
 
-          export GIT_WORK_TREE="$SRC_DIR"
+          # Sync the staged source bundle into the dist working tree,
+          # deleting anything the bundle no longer includes (so removed
+          # files actually disappear from the dist repo). --exclude=.git
+          # protects the cloned metadata directory.
+          rsync -av --delete --exclude='.git' "$SRC_DIR/" ./
 
           git add --all
           git commit --allow-empty --message "Release $DIST_TAG"


### PR DESCRIPTION
## Summary

- The previous `deploy_plugin_dist` step inherited xwp/stream's GIT_DIR/GIT_WORK_TREE-split pattern, which clones the repo into `$DIST_DIR/.git`. Git puts the metadata at `$DIST_DIR/.git/.git/` (nested), so subsequent commands reading `GIT_DIR=$DIST_DIR/.git` find a working tree instead of metadata and error with `fatal: not a git repository`.
- Switch to a plain `git clone REPO $DIST_DIR`, drop the GIT_DIR/GIT_WORK_TREE overrides, and use `rsync -av --delete --exclude='.git'` to swap the working tree contents with the staged source bundle in one pass.

## Test plan

- [x] CI green.
- [ ] After merge, re-run `deploy_plugin_dist` from the last failed `release.yml` run; the clone succeeds, the dist repo's working tree gets replaced with the plugin bundle, and `v<version>` lands on the dist repo.