### PR TITLE
fix: remove static version from WP plugin composer.json

### DIFF
--- a/.changeset/fix-composer-json-no-version.md
+++ b/.changeset/fix-composer-json-no-version.md
@@ -1,0 +1,5 @@
+---
+"@axistaylor/nextpress-wordpress": patch
+---
+
+Remove the static `"version"` field from `packages/wordpress/composer.json`. Packagist derives the package version from the dist repo's git tag (`v<X.Y.Z>` mirrored from the source `wp-v<X.Y.Z>` tag), so a hard-coded `composer.json` version competes with — and on some Composer setups overrides — the tag-derived version. Letting the tag be the single source of truth fixes that.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "packages/wordpress": "1.0.0"
   },
   "scripts": {
-    "update-versions": "ts-node scripts/update-versions.ts",
     "build": "run-p build:backend build:js build:wordpress",
     "build:backend": "npm run build -w ./packages/backend-4-examples",
     "build:js": "npm run build -w ./packages/js",

--- a/packages/wordpress/composer.json
+++ b/packages/wordpress/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "axistaylor/nextpress",
-    "version": "1.0.0",
     "description": "Render WordPress Gutenberg content 1:1 in Next.js. Extends WPGraphQL with enqueued asset queries for headless WordPress implementations.",
     "type": "wordpress-plugin",
     "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- Drop the hard-coded `"version": "1.0.0"` from `packages/wordpress/composer.json`. Packagist derives the package version from the dist repo's git tag (`v<X.Y.Z>`, mirrored from the source `wp-v<X.Y.Z>` tag); a static value competes with the tag-derived version and some Composer setups resolve to the wrong one.
- Verified `scripts/sync-wp-version.ts` only touches `nextpress.php` and `@since TDB` placeholders, and `changesets/cli` only writes to `package.json` files — so nothing in the release pipeline puts `version` back into `composer.json`.

## Test plan

- [ ] CI green.
- [ ] After merge and the next release, `composer show axistaylor/nextpress` shows the tag-derived version (no static fallback), and consumers running `composer require axistaylor/nextpress:^X.Y` resolve cleanly against the dist repo's `v*` tags.