### PR TITLE
fix: stop wrapping proxied .css in @layer wp-base

### DIFF
--- a/.changeset/fix-unlayer-proxied-css.md
+++ b/.changeset/fix-unlayer-proxied-css.md
@@ -1,0 +1,9 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+Stop wrapping proxied `.css` files (`wp-block-library`, plugin/theme CSS) in `@layer wp-base`. Cascade Layers L5 puts layer ordering above specificity, so the previous setup pinned the active theme's compiled stylesheet below theme.json's generic rules — a theme's `.wp-block-button.is-style-cta .wp-block-button__link` (specificity 0,3,0) would lose to theme.json's `.wp-element-button` (0,1,0) regardless of how specific its selector was, breaking button variants, padding, border-radius, and any rule that competed with theme.json defaults.
+
+Now only `globalStyles.stylesheet` + `customCss` live in `@layer wp-theme`; proxied `.css` files stay unlayered and beat theme.json by normal specificity + source order (the same cascade behaviour users see on the WordPress backend). Per-instance core-block-supports inline content also stays unlayered, so the original block-gap override behaviour from the previous release is preserved.
+
+The layer-order declaration emitted by `GlobalStyles` and `AssetUpdater.updateGlobalStyles` is now `@layer wp-theme;` (was `@layer wp-base, wp-theme;`).

--- a/docs/content-css.md
+++ b/docs/content-css.md
@@ -75,57 +75,33 @@ The `:root` selector gives this rule specificity 0,1,0, which it needs to overri
 
 ### Cascade Layers
 
-`@scope` isolates WordPress styles to `[data-rendered]`, but inside the scope NextPress still has to keep three classes of WP-derived CSS from fighting each other:
-
-1. **Proxied stylesheet files** from `assetsByUri` (`wp-block-library`, plugin/theme CSS files) — the lowest-priority foundation.
-2. **`globalStyles.stylesheet` + `customCss`** — the theme.json-derived design tokens that should override the foundation.
-3. **Inline `before`/`after` payloads** from `assetsByUri` (per-instance `core-block-supports` container rules, dynamic plugin styles) — per-page overrides that should win over both.
-
-To enforce that ordering NextPress declares two cascade layers near the top of the head:
+`@scope` isolates WordPress styles to `[data-rendered]`, but inside the scope NextPress still has to keep theme.json's generic design tokens from blocking author CSS (in either the theme's compiled stylesheet or in per-instance block-supports inline content) that has every reason to override them. The fix is a single CSS cascade layer for theme.json:
 
 ```css
-@layer wp-base, wp-theme;
+@layer wp-theme;
 ```
-
-…and routes each class of WP CSS into the appropriate tier:
 
 | Source | Path | Wrapping |
 |--------|------|----------|
-| Proxied `.css` files (any `assetsByUri` handle with a `src`) | `proxyByWCR.ts` | `@layer wp-base { @scope ([data-rendered]) { … } }` |
 | `globalStyles.stylesheet` + `customCss` | `GlobalStyles.tsx`, `AssetUpdater.updateGlobalStyles` | `@layer wp-theme { @scope ([data-rendered]) { … } }` |
-| `before` / `after` inline content on any `assetsByUri` handle | `Stylesheets.tsx`, `AssetUpdater.updateStylesheets` | `@scope ([data-rendered]) { … }` — unlayered |
+| Proxied `.css` files (any `assetsByUri` handle with a `src` — `wp-block-library`, plugin/theme CSS) | `proxyByWCR.ts` | `@scope ([data-rendered]) { … }` — unlayered |
+| `before` / `after` inline content on any `assetsByUri` handle (per-instance `core-block-supports`, dynamic plugin inline styles) | `Stylesheets.tsx`, `AssetUpdater.updateStylesheets` | `@scope ([data-rendered]) { … }` — unlayered |
 | App CSS (Tailwind, your `globals.css`) | n/a | unlayered |
 | Inline `style="…"` attributes | n/a | always wins |
 
-CSS Cascade Layers L5 says unlayered author rules beat any layered author rules, and later-declared layers beat earlier ones. So the resulting cascade priority is:
+CSS Cascade Layers L5 says unlayered author rules beat any layered author rules. So the resulting cascade priority is:
 
 ```
-wp-base  <  wp-theme  <  unlayered (Stylesheets + app CSS)  <  inline style="…"
+wp-theme (theme.json)  <  unlayered (proxied .css + Stylesheets inline + app CSS)  <  inline style="…"
 ```
 
-This makes per-instance block-supports CSS (e.g. an editor-set `style.spacing.blockGap` on a `core/columns` block) reliably override the matching theme.json default — even when both rules have the same selector specificity and the theme.json rule appears later in the document.
+This makes per-instance block-supports CSS (e.g. an editor-set `style.spacing.blockGap` on a `core/columns` block) reliably override the matching theme.json default — even when both rules have the same selector specificity and the theme.json rule appears later in the document. It also lets the active theme's compiled stylesheet (`.wp-block-button.is-style-cta .wp-block-button__link { background: var(--accent); }`, etc.) beat theme.json's generic `.wp-element-button` rules by normal specificity, the same way it does on the WordPress backend.
+
+> **Why not layer proxied .css too?** An earlier version of NextPress wrapped every proxied .css file in `@layer wp-base` (below `wp-theme`). That was too aggressive: a theme's specific button-variant rule, no matter how specific its selector, would lose to theme.json's generic button rule, because layer ordering trumps specificity. Leaving proxied .css unlayered restores the cascade users expect from the WordPress backend.
 
 #### Differentiation Is Source-Based, Never Handle-Based
 
 NextPress never branches on specific WP handle names (e.g. `core-block-supports`, `wp-block-library`). The layering only looks at *which payload field* a chunk of CSS came from — `globalStyles` field, `assetsByUri` external file, or `assetsByUri` inline `before`/`after`. Any WP setup that exposes those fields gets the correct cascade for free; classic themes, FSE block themes, plugin-only sites, and headless-first installs all work without nextpress needing to know what's installed.
-
-#### Nested `@layer` Inside Proxied Files
-
-A proxied `.css` file may already contain its own `@layer` rules (Tailwind v4 emits `@layer theme { … }`, plugin bundles may use `@layer base, components, utilities;`). When `scopeStylesheet(css, { layer: 'wp-base' })` wraps that file, the result is:
-
-```css
-@layer wp-base {
-  @scope ([data-rendered]) {
-    @layer theme { /* original file's layer */ }
-    .unlayered-rule { /* original file's unlayered rule */ }
-  }
-}
-```
-
-Per CSS Cascade L5, `@layer theme` becomes a sublayer named `wp-base.theme`. Two consequences:
-
-- Internal ordering within the file is preserved (relative `foo` vs `bar` order inside the file is kept as `wp-base.foo` vs `wp-base.bar`).
-- Anything that was unlayered in the original file becomes the implicit outer of `wp-base`, capping its maximum priority at the `wp-base` tier. A plugin that previously used unlayered CSS to override theme.json defaults loses that ability — that's intentional. Plugin CSS that genuinely needs to win against theme.json should be exposed as inline `before`/`after` (via `wp_add_inline_style()`), which stays unlayered.
 
 #### Variables Are Never Layered
 
@@ -135,7 +111,7 @@ The extractor preserves a `:root` block's original `@layer` wrapper if it had on
 
 #### Why `global-styles` Is Skipped Server-Side
 
-WordPress's `wp_enqueue_global_styles()` adds `wp_get_global_stylesheet()` as inline-after content on the `global-styles` handle — duplicating the same content that NextPress already exposes through the dedicated `globalStyles.stylesheet` GraphQL field. If both reached the browser, the unlayered Stylesheets copy would beat the `@layer wp-theme` copy and per-instance overrides would never win.
+WordPress's `wp_enqueue_global_styles()` adds `wp_get_global_stylesheet()` as inline-after content on the `global-styles` handle — duplicating the same content that NextPress already exposes through the dedicated `globalStyles.stylesheet` GraphQL field. If both reached the browser the duplicate would compete with — and on some renders win against — the canonical wp-theme copy via source-order accidents.
 
 To prevent that, NextPress's WP plugin filters the `global-styles` handle out of the enqueued queue in `WP_Assets::flatten_enqueued_assets_list()`. The theme.json content still reaches the frontend via `globalStyles.stylesheet`; the unlayered duplicate just disappears.
 
@@ -363,15 +339,17 @@ A block's `margin` shorthand overrides the layout's `margin-block-start`:
 
 ### A theme.json default for a block isn't overriding `wp-block-library` defaults
 
-Theme.json output lives in `@layer wp-theme`; proxied `wp-block-library` CSS lives in `@layer wp-base`. wp-theme beats wp-base, so a theme.json `styles.blocks.<name>` rule should win — *unless* theme.json's emitted selector is less specific than the matching `wp-block-library` rule (e.g. `:scope :where(.X)` (0,1,0) vs `.wp-block-X.is-layout-flex` (0,2,0)). Increase the theme.json selector's specificity or override via a per-instance editor setting (which lands unlayered and wins regardless).
+theme.json output lives in `@layer wp-theme`; proxied `wp-block-library` CSS is unlayered. Unlayered author CSS beats any layer, so `wp-block-library` will win wherever its selector matches and its specificity is at least as high as theme.json's. theme.json uses `:where()` extensively, which zeros out specificity, so a theme.json rule like `:scope :where(.is-layout-flex){gap: var(--spacing-X)}` (0,1,0) loses to `wp-block-library`'s plain `.wp-block-X.is-layout-flex` (0,2,0) regardless of layer ordering.
+
+To make theme.json win in those cases, either tighten the theme.json selector via the WP plugin's style engine settings, or override on a per-block instance via the editor (per-instance core-block-supports rules also land unlayered, and they're emitted with selectors specific enough to beat `wp-block-library`).
 
 ### A per-instance block setting isn't winning over a theme.json default
 
-This is what cascade layers are for. If a `style.spacing.blockGap` (or padding/margin) set on a specific block in the editor isn't overriding the matching theme.json default:
+This is what the `wp-theme` layer is for. If a `style.spacing.blockGap` (or padding/margin) set on a specific block in the editor isn't overriding the matching theme.json default:
 
 1. Check that `settings.spacing.blockGap` (or padding/margin) is `true` in theme.json — without that flag, the editor doesn't emit per-instance overrides at all.
 2. Confirm the per-instance rule appears in a `<style>` element WITHOUT an `@layer` wrapper. It should sit inside `@scope ([data-rendered]) { … }` but not inside any `@layer`. If it's accidentally inside `wp-theme`, the cascade won't bump it above the theme.json default.
-3. Verify `WP_Assets::flatten_enqueued_assets_list()` is still skipping the `global-styles` handle. If that filter is missing, the duplicate unlayered copy of theme.json reaches the browser and beats the per-instance override.
+3. Verify `WP_Assets::flatten_enqueued_assets_list()` is still skipping the `global-styles` handle. If that filter is missing, the duplicate unlayered copy of theme.json reaches the browser, undoing the wp-theme/unlayered split.
 
 ## Related
 

--- a/packages/e2e-tests/tests/style-layers.spec.ts
+++ b/packages/e2e-tests/tests/style-layers.spec.ts
@@ -3,19 +3,21 @@ import { test, expect } from '@playwright/test';
 /**
  * Style Layer Tests
  *
- * Validates that NextPress wraps WP-derived CSS in cascade layers so the
- * cascade priority is:
+ * Validates that NextPress wraps theme.json's globalStyles in
+ * `@layer wp-theme` so per-instance block-supports CSS (and any other
+ * unlayered author CSS) reliably override theme.json defaults.
  *
- *   wp-base (proxied .css from assetsByUri)
- *   < wp-theme (globalStyles.stylesheet + customCss)
- *   < unlayered (Stylesheets before/after inline content from assetsByUri,
- *     app CSS)
- *   < inline style="..."
+ *   wp-theme (globalStyles.stylesheet + customCss) — lowest priority
+ *   < unlayered (proxied .css from assetsByUri, Stylesheets before/after
+ *     inline content, app CSS) — beats wp-theme by being unlayered
+ *   < inline style="..." — always wins
  *
- * This makes per-instance block-supports CSS (e.g. blockGap explicitly set
- * to 0 on a core/columns block) reliably win over theme.json defaults,
- * even when theme.json output appears later in the document via duplicate
- * style emissions.
+ * Proxied .css files (wp-block-library, plugin/theme CSS) intentionally
+ * stay unlayered so author styles can still override theme.json defaults
+ * via normal specificity + source order — wrapping them in a layer was
+ * too aggressive (e.g. a theme's `.is-style-cta .wp-block-button__link`
+ * rule would lose to theme.json's generic `.wp-element-button` rule even
+ * at higher specificity).
  *
  * Seeded pages (live in the dev backup SQL dump):
  * - /test-layer-zero-blockgap — columns block with style.spacing.blockGap
@@ -32,22 +34,18 @@ test.describe('Style Cascade Layers — Structure', () => {
     await page.waitForLoadState('domcontentloaded');
   });
 
-  test('@layer wp-base, wp-theme is declared before any layered content', async ({ page }) => {
+  test('@layer wp-theme is declared before any layered content', async ({ page }) => {
     const layerOrder = await page.locator('#nextpress-layer-order').textContent();
-    expect(layerOrder).toContain('@layer wp-base, wp-theme;');
+    expect(layerOrder).toContain('@layer wp-theme;');
 
-    // Layer order must come before any @layer wp-base { ... } or
-    // @layer wp-theme { ... } content. Otherwise the order is determined
-    // by first-encounter and we lose the guarantee.
+    // Layer order must come before any @layer wp-theme { ... } content,
+    // otherwise the order is determined by first-encounter and we lose
+    // the guarantee that wp-theme registers as the lowest layer.
     const html = await page.content();
-    const orderDeclIdx = html.indexOf('@layer wp-base, wp-theme;');
-    const firstLayerBaseIdx = html.indexOf('@layer wp-base {');
+    const orderDeclIdx = html.indexOf('@layer wp-theme;');
     const firstLayerThemeIdx = html.indexOf('@layer wp-theme {');
 
     expect(orderDeclIdx).toBeGreaterThan(-1);
-    if (firstLayerBaseIdx !== -1) {
-      expect(orderDeclIdx).toBeLessThan(firstLayerBaseIdx);
-    }
     if (firstLayerThemeIdx !== -1) {
       expect(orderDeclIdx).toBeLessThan(firstLayerThemeIdx);
     }
@@ -66,7 +64,7 @@ test.describe('Style Cascade Layers — Structure', () => {
     );
   });
 
-  test('proxied .css files come back wrapped in @layer wp-base', async ({ page }) => {
+  test('proxied .css files stay unlayered (only @scope-wrapped)', async ({ page }) => {
     const proxiedCssBodies: string[] = [];
 
     page.on('response', async (response) => {
@@ -86,8 +84,11 @@ test.describe('Style Cascade Layers — Structure', () => {
 
     expect(proxiedCssBodies.length).toBeGreaterThan(0);
     for (const body of proxiedCssBodies) {
-      expect(body).toContain('@layer wp-base {');
       expect(body).toContain('@scope ([data-rendered]) {');
+      // Proxied CSS must stay unlayered so author styles override
+      // theme.json defaults via normal specificity + source order.
+      expect(body).not.toContain('@layer wp-base');
+      expect(body).not.toContain('@layer wp-theme');
     }
   });
 
@@ -120,7 +121,7 @@ test.describe('Style Cascade Layers — Structure', () => {
 });
 
 test.describe('Style Cascade Layers — Behavior', () => {
-  test('columns with explicit blockGap=0 win over theme.json default (48px)', async ({ page }) => {
+  test('columns with explicit blockGap=0 win over theme.json default', async ({ page }) => {
     await page.goto('/test-layer-zero-blockgap');
     await page.waitForLoadState('domcontentloaded');
 
@@ -189,39 +190,5 @@ test.describe('Style Cascade Layers — Behavior', () => {
 
     expect(result.layeredOnly).toBe('rgb(255, 0, 0)');
     expect(result.afterUnlayered).toBe('rgb(0, 0, 255)');
-  });
-
-  test('wp-theme layered rules beat wp-base layered rules', async ({ page }) => {
-    await page.goto('/test-layer-default-blockgap');
-    await page.waitForLoadState('domcontentloaded');
-
-    const result = await page.evaluate(() => {
-      const target = document.createElement('div');
-      target.id = 'nextpress-cascade-probe';
-      const scope = document.querySelector('[data-rendered]');
-      (scope || document.body).appendChild(target);
-
-      const base = document.createElement('style');
-      base.textContent =
-        '@layer wp-base { @scope ([data-rendered]) { #nextpress-cascade-probe { color: rgb(0, 128, 0); } } }';
-      document.head.appendChild(base);
-      const baseOnly = getComputedStyle(target).color;
-
-      const theme = document.createElement('style');
-      theme.textContent =
-        '@layer wp-theme { @scope ([data-rendered]) { #nextpress-cascade-probe { color: rgb(128, 0, 128); } } }';
-      document.head.appendChild(theme);
-      const afterTheme = getComputedStyle(target).color;
-
-      base.remove();
-      theme.remove();
-      target.remove();
-      return { baseOnly, afterTheme };
-    });
-
-    expect(result.baseOnly).toBe('rgb(0, 128, 0)');
-    // wp-theme wins because it was declared after wp-base in the layer-order
-    // statement (@layer wp-base, wp-theme).
-    expect(result.afterTheme).toBe('rgb(128, 0, 128)');
   });
 });

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -288,10 +288,10 @@ function updateGlobalStyles(
 
   const head = document.head;
 
-  // Re-register layer order on every navigation so the cascade priority of
-  // wp-base (proxied .css) and wp-theme (globalStyles) is preserved when
-  // the previous declaration was torn down with the rest of the global tags.
-  const layerOrder = createStyleElement('nextpress-layer-order', '@layer wp-base, wp-theme;');
+  // Re-register the wp-theme layer on every navigation so theme.json
+  // globalStyles stay below proxied CSS and unlayered author rules in
+  // the cascade after the previous declaration is torn down.
+  const layerOrder = createStyleElement('nextpress-layer-order', '@layer wp-theme;');
   layerOrder.setAttribute('data-nextpress', 'global');
   head.appendChild(layerOrder);
 

--- a/packages/js/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/js/src/GlobalStyles/GlobalStyles.tsx
@@ -39,17 +39,20 @@ export function GlobalStyles({
   return (
     <Fragment>
       {/*
-        Register layer order before any layered content loads. wp-base is the
-        lowest tier (proxied .css files from assetsByUri — wp-block-library,
-        plugin/theme CSS files); wp-theme sits above (globalStyles +
-        customCss). Everything else stays unlayered and wins over both,
-        which is what we want for per-instance core-block-supports rules
-        and app-level CSS.
+        Register the wp-theme layer up front so theme.json globalStyles
+        live below every other source of WP CSS in the cascade. Proxied
+        .css (wp-block-library, plugin/theme CSS) stays unlayered so
+        author styles can still override theme.json defaults by normal
+        specificity + source order — wrapping proxied CSS in a layer was
+        too aggressive (a theme's button.is-style-cta would lose to
+        theme.json's generic button rule even at higher specificity).
+        Per-instance core-block-supports inline content also stays
+        unlayered so explicit block overrides still beat theme.json.
       */}
       <style
         id="nextpress-layer-order"
         data-nextpress="global"
-        dangerouslySetInnerHTML={{ __html: '@layer wp-base, wp-theme;' }}
+        dangerouslySetInnerHTML={{ __html: '@layer wp-theme;' }}
       />
       {fontFaceCss && (
         <style

--- a/packages/js/src/proxyByWCR/proxyByWCR.ts
+++ b/packages/js/src/proxyByWCR/proxyByWCR.ts
@@ -128,7 +128,7 @@ export async function proxyByWCR(request: Request & { nextUrl: { pathname: strin
       }
 
       const css = await response.text();
-      const scopedCss = scopeStylesheet(css, { layer: 'wp-base' });
+      const scopedCss = scopeStylesheet(css);
 
       return new NextResponse(scopedCss, {
         status: 200,
@@ -155,7 +155,7 @@ export async function proxyByWCR(request: Request & { nextUrl: { pathname: strin
       }
 
       const css = await response.text();
-      const scopedCss = scopeStylesheet(css, { layer: 'wp-base' });
+      const scopedCss = scopeStylesheet(css);
 
       return new NextResponse(scopedCss, {
         status: 200,


### PR DESCRIPTION
## Summary

- Cascade Layers L5 puts layer ordering above specificity, so the previous setup (proxied `.css` in `@layer wp-base`, theme.json globalStyles in `@layer wp-theme`) pinned the active theme's compiled stylesheet below theme.json's generic rules. A theme's specific variant selector like `.wp-block-button.is-style-cta .wp-block-button__link` (0,3,0) would lose to theme.json's `.wp-element-button` (0,1,0) regardless of specificity — breaking button variants, padding, border-radius, and anything that competed with a theme.json default. The WordPress backend doesn't have this problem because it doesn't use cascade layers.
- Drop the layer wrap for proxied `.css`. Only `globalStyles.stylesheet` + `customCss` stay in `@layer wp-theme`. Per-instance core-block-supports rules remain unlayered and still beat theme.json defaults, so the block-gap fix from the previous release is preserved.
- Layer-order declaration is now `@layer wp-theme;` (down from `@layer wp-base, wp-theme;`).
- Tests + docs/content-css.md updated to reflect the single-layer model.

## Test plan

- [x] `npx jest` — 108/108 passing.
- [x] `npm run typecheck` clean.
- [ ] Playwright `style-layers.spec.ts`: structure tests assert proxied `.css` is unlayered and the layer-order declaration is `@layer wp-theme;`; behavioural tests for per-instance blockGap override and theme.json fallback unchanged.