### PR TITLE
fix(changeset): retarget WP plugin fix to @axistaylor/nextpress-wordpress

### DIFF
--- a/.changeset/fix-script-modules-static-conflict.md
+++ b/.changeset/fix-script-modules-static-conflict.md
@@ -1,5 +1,5 @@
 ---
-"@axistaylor/nextpress": patch
+"@axistaylor/nextpress-wordpress": patch
 ---
 
 `NextPress_Script_Modules extends \WP_Script_Modules` was redeclaring `get_registered()` as a `static` method. WP 6.7 shipped a non-static public `WP_Script_Modules::get_registered()`, and PHP refuses to change a method's static-ness in a subclass — the plugin fatals on load with "Cannot make non static method WP_Script_Modules::get_registered() static …", taking the plugin (and the e2e suite) down before anything could boot.


### PR DESCRIPTION
## Summary

- The script-modules + stylesheet-test fix changes were all in `packages/wordpress/` (the WP plugin, published as `@axistaylor/nextpress-wordpress`).
- The original changeset incorrectly attributed the bump to `@axistaylor/nextpress` (the JS package at `packages/js/`), which carries none of those changes.
- Retarget the changeset to the WP plugin so the next release bumps the right package. Once merged, the changeset action will regenerate the existing "Version Packages" PR (#48) with the corrected version map.

## Test plan

- [ ] On merge, watch the changeset action update PR #48 to bump `@axistaylor/nextpress-wordpress` instead of `@axistaylor/nextpress`.