### PR TITLE
fix: strip CSS comments before scope rewrite so :root extraction survives docblocks

### DIFF
--- a/.changeset/fix-scope-styles-tolerate-comments.md
+++ b/.changeset/fix-scope-styles-tolerate-comments.md
@@ -1,0 +1,11 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+Strip CSS block comments at the top of `scopeStylesheet` so downstream passes — `extractCSSVariables`, `isVariablesOnly`, the `:root` → `:scope` rewrite — run on canonical CSS. Fixes two related bugs that surfaced when authors put docblocks inside a `:root { … }` rule:
+
+1. **Variables-only blocks falling through to the scope rewrite.** `isVariablesOnly` splits the block content on `;` and asserts each piece starts with `--`. A `/* docblock */` between declarations produced a piece starting with `/`, so the check returned false and the block ended up as `:scope { … }` inside `@scope ([data-rendered])` instead of being extracted to global `:root { … }`. In practice that meant scoped light-mode tokens silently shadowed `:root.dark` overrides for descendants of the scope element, so toggling dark mode left the WP-rendered content area stuck on light colours.
+
+2. **Selectors hiding inside comments accidentally matching the rewrite regexes.** A construct like `body /* comment */ { … }` left the `body` token visible to the `body` → `&` rewrite from the wrong position. Stripping comments first eliminates the class entirely.
+
+`isVariablesOnly` itself is unchanged; comments are now stripped before any pass sees the CSS. Tests cover both the comment-tolerant extraction path and the case where genuine non-variable declarations alongside comments still scope correctly.

--- a/packages/js/src/utils/scopeStyles.spec.ts
+++ b/packages/js/src/utils/scopeStyles.spec.ts
@@ -91,6 +91,68 @@ describe('scopeStylesheet', () => {
     expect(out).toContain(':root:where(.dark){--fg: white;}');
   });
 
+  it('extracts :root blocks even when they contain inline CSS comments', () => {
+    // Regression: a `/* … */` between declarations made `isVariablesOnly`
+    // return false (split-by-`;` produced a piece starting with `/`, not
+    // `--`). The block fell through to the scope rewrite and became
+    // `:scope { … }`, shadowing dark-mode tokens for descendants of the
+    // scope element. Comments are stripped at the top of scopeStylesheet
+    // so this kind of authoring no longer breaks extraction.
+    const css = `:root {
+      --fg: cello;
+      /* Gradient docblock that previously broke extraction.
+       * Multi-line, with intentionally tricky tokens like ; and {} in prose.
+       */
+      --gradient: linear-gradient(180deg, red, blue);
+    }`;
+    const out = scopeStylesheet(css);
+    expect(out).toMatch(/^:root\{/);
+    expect(out).toContain('--fg: cello');
+    expect(out).toContain('--gradient: linear-gradient(180deg, red, blue)');
+    // No comment text survives in the output.
+    expect(out).not.toContain('Gradient docblock');
+    // Nothing leaks back into the @scope wrapper.
+    const scopeStart = out.indexOf('@scope (');
+    expect(out.indexOf(':scope', scopeStart)).toBe(-1);
+  });
+
+  it('extracts :root.dark blocks that contain inline comments', () => {
+    const css = `:root.dark {
+      /* Dark-theme tokens */
+      --bg: black;
+      --fg: white;
+    }`;
+    const out = scopeStylesheet(css);
+    expect(out).toContain(':root.dark{');
+    expect(out).toContain('--bg: black');
+    expect(out).toContain('--fg: white');
+  });
+
+  it('still scopes :root blocks that mix variables with real declarations', () => {
+    // Comment-stripping must not paper over genuine non-variable rules.
+    // A block with `color: blue` alongside `--foo` is NOT variables-only
+    // and must go through the scope rewrite.
+    const css = ':root { /* a comment */ --foo: red; color: blue; }';
+    const out = scopeStylesheet(css);
+    expect(out).not.toMatch(/^:root\{/);
+    // The stripped block reaches the rewrite without the comment text.
+    // (Whitespace left where the comment used to be is fine — CSS doesn't
+    // care, and collapsing it could merge tokens elsewhere.)
+    expect(out).toMatch(/:scope\s*\{\s*--foo:\s*red;\s*color:\s*blue;\s*\}/);
+    expect(out).not.toContain('a comment');
+  });
+
+  it('strips selector-position comments before the scope rewrite', () => {
+    // A comment inside or beside a selector shouldn't break selector
+    // matching downstream. After stripping, the selector is canonical.
+    const css = `body /* leading */ { margin: 0; } /* between */ .x { color: red; }`;
+    const out = scopeStylesheet(css);
+    expect(out).toMatch(/&\s*\{\s*margin:\s*0;\s*\}/);
+    expect(out).toMatch(/\.x\s*\{\s*color:\s*red;\s*\}/);
+    expect(out).not.toContain('leading');
+    expect(out).not.toContain('between');
+  });
+
   it('does NOT extract :root with descendant combinators (those are real descendant rules)', () => {
     // `:root .foo` is a descendant selector — not a root variable block.
     // It must NOT be extracted; the `.foo` part is a real scoped match.

--- a/packages/js/src/utils/scopeStyles.ts
+++ b/packages/js/src/utils/scopeStyles.ts
@@ -1,8 +1,28 @@
 const SCOPE_SELECTOR = '[data-rendered]';
 
 /**
- * Returns true when every semicolon-separated declaration in the block
- * is a CSS custom property (--name: value).
+ * Strips CSS block comments from a string. CSS comments can't nest, so a
+ * non-greedy match between the slash-star and star-slash delimiters is
+ * sufficient.
+ *
+ * Comments are stripped once at the top of `scopeStylesheet` so every
+ * downstream pass — `extractCSSVariables`, `isVariablesOnly`, the
+ * `:root` -> `:scope` rewrite — runs on canonical CSS. This avoids two
+ * classes of bug:
+ *
+ *  1. Variables-only blocks slipping through to the scope rewrite
+ *     because a docblock between declarations made `isVariablesOnly`
+ *     return false (split-by-`;` produced a piece starting with `/`).
+ *  2. Selectors hiding inside comments accidentally matching the
+ *     `:root` / `body` / `html` rewrite regexes.
+ */
+function stripCssComments(content: string): string {
+  return content.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Returns true when every semicolon-separated declaration in the block is a
+ * CSS custom property (`--name: value`).
  */
 function isVariablesOnly(content: string): boolean {
   return content
@@ -92,16 +112,18 @@ export interface ScopeStylesheetOptions {
 /**
  * Scopes a stylesheet to only apply within [data-rendered] elements.
  *
- * Extracts :root variable-only blocks and emits them globally (CSS variables
- * are inert until referenced via var() so they're safe to leave unscoped).
- * Rewrites remaining body/html/:root selectors to the scope root reference (&)
- * and wraps in @scope, optionally inside @layer.
+ * Strips CSS block comments up front, then extracts :root variable-only
+ * blocks and emits them globally (CSS variables are inert until referenced
+ * via var() so they're safe to leave unscoped). Rewrites remaining
+ * body/html/:root selectors to the scope root reference (&) and wraps in
+ * @scope, optionally inside @layer.
  */
 export function scopeStylesheet(
   css: string,
   options: ScopeStylesheetOptions = {},
 ): string {
-  const { variables, rest } = extractCSSVariables(css);
+  const stripped = stripCssComments(css);
+  const { variables, rest } = extractCSSVariables(stripped);
 
   // Rewrite body, html, and :root selectors to & (scope root reference)
   // Handles: body, html, body.class, html[attr], :root :where(...), etc.


### PR DESCRIPTION
## Summary

`scopeStylesheet` now strips `/* … */` block comments at the top of the pipeline so `extractCSSVariables`, `isVariablesOnly`, and the `:root` → `:scope` rewrite all run on canonical CSS.

The driving bug: `isVariablesOnly` splits the block content on `;` and asserts each piece starts with `--`. A docblock between declarations inside a `:root { … }` rule produced a piece starting with `/`, the check returned false, and the block ended up as `:scope { … }` inside the `@scope ([data-rendered])` wrapper instead of being extracted to global `:root { … }`. In practice that meant scoped light-mode tokens silently shadowed `:root.dark` overrides for descendants of the scope element, so toggling dark mode left WP-rendered content stuck on light colours.

Hit this on woographql.com: `brand.css` has multi-line gradient documentation comments inside the same `:root { … }` rule as the theme tokens. Removing the comments from the source unblocked the immediate issue; this PR is the upstream fix so future docblock authoring doesn't bite anyone else.

Side benefit: selector-position comments (`body /* … */ { … }`) no longer interfere with the `body` / `html` / `:root` rewrites either.

## Test plan

- [x] `cd packages/js && npm test scopeStyles` — 18 tests pass, including four new regression specs:
  - `:root` with inline docblocks extracts globally with original selector
  - `:root.dark` with inline comments extracts globally
  - `:root` that mixes variables with non-variable declarations still scopes (comment-stripping doesn't paper over genuine non-variable rules)
  - selector-position comments are stripped before the rewrite