### PR TITLE
fix: asset URL rewriting and script dep ordering for headless WP

### DIFF
--- a/.changeset/fix-asset-url-rewriting-and-script-ordering.md
+++ b/.changeset/fix-asset-url-rewriting-and-script-ordering.md
@@ -1,0 +1,18 @@
+---
+"@axistaylor/nextpress": patch
+"@axistaylor/nextpress-wordpress": patch
+---
+
+Fix asset URL rewriting and script dependency ordering for headless WP setups.
+
+**`@axistaylor/nextpress`**
+
+- `Stylesheets` and `AssetUpdater` now preserve external asset URLs (Google Fonts, CDNs) including their query strings, instead of stripping the scheme/host/query and routing them through the WP asset proxy where they 404.
+- Protocol-relative URLs (`//host/path`, common in WC enqueues via `set_url_scheme()`) are parsed correctly. Previously `new URL()` threw, the catch returned the input unchanged, and the host ended up as a path segment (`/wp-assets//host/...`).
+- WP-instance matching compares hosts instead of full origins so scheme mismatches (http asset on https backend) and protocol-relative URLs still resolve to the configured backend.
+- New shared `resolveAssetHref` helper consolidates the foreign-instance / external / current-instance branching across `Stylesheets`, `AssetUpdater` (`updateStylesheets`, `updateScripts`, `updateImportMap`).
+
+**`@axistaylor/nextpress-wordpress`**
+
+- `WP_Assets::flatten_enqueued_assets_list` now appends each resolved dependency just before its dependent in the output list, instead of `array_unshift`-ing all dependencies to the very front of the handles array. The old behavior front-loaded dependencies regardless of which queue items needed them, breaking relative ordering for scripts that rely on implicit load order (e.g. `wc-order-attribution` loading after `wc-stripe-blocks-integration` caused `setOrderTracking is not a function` at runtime).
+- New `Assets::skip_unbootstrapped_wc_handles` callback on the `nextpress/graphql/uri-assets/skip_script_module_dependency` filter drops `woocommerce-services-store-notices` from the enqueued asset list when WC Services' `tos_accepted` flag is false. Without TOS, the Store API extension that populates `cart.extensions["woocommerce-services"]` never registers, and the script crashes at runtime trying to read it on US-address checkouts. Gated on the existing `enable_custom_wc_scripts` setting.

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -1,17 +1,11 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { EnqueuedScript, EnqueuedStylesheet, GlobalStylesType, ScriptLoadingGroupEnum, ScriptTypeEnum } from '@/types';
 import { WPImport } from '@/ImportMap';
-import { getAllWPInstances, getWPInstance } from '@/config/getWPInstance';
 import { scopeInlineStyles } from '@/utils/scopeStyles';
-import { resolveAssetHref } from '@/utils/url';
+import { transformAssetUrl } from '@/utils/url';
 import { firePageEvents } from '@/hooks/usePageEvents';
 import { joinScriptContent } from '@/utils/content';
 import { replaceProxyPlaceholders, processWcSettings } from '@/compatibility/woocommerce';
-
-interface AssetContext {
-  wpHomeUrl: string;
-  otherInstances: Record<string, string>;
-}
 
 export interface AssetData {
   stylesheets: EnqueuedStylesheet[];
@@ -131,7 +125,7 @@ function createScriptElement(
 /**
  * Replaces the stylesheet list between the nextpress-stylesheets-start/end markers.
  */
-function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string, ctx: AssetContext): void {
+function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string): void {
   const range = clearBetweenMarkers(
     'nextpress-stylesheets-start',
     'nextpress-stylesheets-end',
@@ -156,7 +150,7 @@ function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string, 
 
     if (stylesheet.src) {
       parent.insertBefore(
-        createLinkElement(handle, resolveAssetHref(stylesheet.src, instance, ctx.wpHomeUrl, ctx.otherInstances)),
+        createLinkElement(handle, transformAssetUrl(stylesheet.src, instance)),
         endMarker,
       );
     }
@@ -183,7 +177,6 @@ async function updateScripts(
   endId: string,
   instance: string,
   pathname: string,
-  ctx: AssetContext,
 ): Promise<void> {
   const range = clearBetweenMarkers(startId, endId);
   if (!range) return;
@@ -242,7 +235,7 @@ async function updateScripts(
     // ES modules don't have inline extra/before/after scripts — just load the src.
     if (isModule) {
       if (script.src) {
-        await insert(handle, { src: resolveAssetHref(script.src, instance, ctx.wpHomeUrl, ctx.otherInstances), isModule: true });
+        await insert(handle, { src: transformAssetUrl(script.src, instance), isModule: true });
       }
       continue;
     }
@@ -270,7 +263,7 @@ async function updateScripts(
     }
 
     if (script.src) {
-      await insert(handle, { src: resolveAssetHref(script.src, instance, ctx.wpHomeUrl, ctx.otherInstances) });
+      await insert(handle, { src: transformAssetUrl(script.src, instance) });
     }
 
     const afterScript = joinScriptContent(script.after);
@@ -346,7 +339,6 @@ function updateImportMap(
   imports: WPImport[] | null | undefined,
   instance: string,
   pathname: string,
-  ctx: AssetContext,
 ): void {
   const existing = document.getElementById('wp-importmap');
   if (existing) {
@@ -358,7 +350,7 @@ function updateImportMap(
   const map: Record<string, string> = {};
   for (const entry of imports) {
     // Paths use the RELATIVE scheme — route through the asset proxy.
-    map[entry.name] = resolveAssetHref(entry.path, instance, ctx.wpHomeUrl, ctx.otherInstances);
+    map[entry.name] = transformAssetUrl(entry.path, instance);
   }
 
   const el = document.createElement('script');
@@ -388,19 +380,6 @@ export function AssetUpdater({
   // pathname) re-fetches and re-applies assets.
   const hasMounted = useRef(false);
 
-  const assetContext = useMemo<AssetContext>(() => {
-    const { wpHomeUrl } = getWPInstance(instance);
-    const otherInstances = Object.entries(getAllWPInstances())
-      .reduce((acc, [slug, entry]) => {
-        if (entry.wpHomeUrl === wpHomeUrl) {
-          return acc;
-        }
-        acc[slug] = entry.wpHomeUrl;
-        return acc;
-      }, {} as Record<string, string>);
-    return { wpHomeUrl, otherInstances };
-  }, [instance]);
-
   useEffect(() => {
     if (!hasMounted.current) {
       hasMounted.current = true;
@@ -417,9 +396,9 @@ export function AssetUpdater({
         const assets = await fetchAssets(pathname);
         if (cancelled) return;
 
-        updateStylesheets(assets.stylesheets, instance, assetContext);
+        updateStylesheets(assets.stylesheets, instance);
         updateGlobalStyles(assets.globalStyles, instance, pathname);
-        updateImportMap(assets.importMap, instance, pathname, assetContext);
+        updateImportMap(assets.importMap, instance, pathname);
 
         // Insert head scripts sequentially, then body scripts sequentially,
         // so each script (inline or external) finishes executing before the
@@ -431,7 +410,6 @@ export function AssetUpdater({
           'nextpress-head-scripts-end',
           instance,
           pathname,
-          assetContext,
         );
         if (cancelled) return;
 
@@ -442,7 +420,6 @@ export function AssetUpdater({
           'nextpress-body-scripts-end',
           instance,
           pathname,
-          assetContext,
         );
         if (cancelled) return;
 
@@ -456,7 +433,7 @@ export function AssetUpdater({
     return () => {
       cancelled = true;
     };
-  }, [pathname, instance, fetchAssets, assetContext]);
+  }, [pathname, instance, fetchAssets]);
 
   return null;
 }

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { EnqueuedScript, EnqueuedStylesheet, GlobalStylesType, ScriptLoadingGroupEnum, ScriptTypeEnum } from '@/types';
 import { WPImport } from '@/ImportMap';
+import { getAllWPInstances, getWPInstance } from '@/config/getWPInstance';
 import { scopeInlineStyles } from '@/utils/scopeStyles';
-import { transformAssetUrl } from '@/utils/url';
+import { resolveAssetHref } from '@/utils/url';
 import { firePageEvents } from '@/hooks/usePageEvents';
 import { joinScriptContent } from '@/utils/content';
 import { replaceProxyPlaceholders, processWcSettings } from '@/compatibility/woocommerce';
+
+interface AssetContext {
+  wpHomeUrl: string;
+  otherInstances: Record<string, string>;
+}
 
 export interface AssetData {
   stylesheets: EnqueuedStylesheet[];
@@ -125,7 +131,7 @@ function createScriptElement(
 /**
  * Replaces the stylesheet list between the nextpress-stylesheets-start/end markers.
  */
-function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string): void {
+function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string, ctx: AssetContext): void {
   const range = clearBetweenMarkers(
     'nextpress-stylesheets-start',
     'nextpress-stylesheets-end',
@@ -150,7 +156,7 @@ function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string):
 
     if (stylesheet.src) {
       parent.insertBefore(
-        createLinkElement(handle, transformAssetUrl(stylesheet.src, instance)),
+        createLinkElement(handle, resolveAssetHref(stylesheet.src, instance, ctx.wpHomeUrl, ctx.otherInstances)),
         endMarker,
       );
     }
@@ -177,6 +183,7 @@ async function updateScripts(
   endId: string,
   instance: string,
   pathname: string,
+  ctx: AssetContext,
 ): Promise<void> {
   const range = clearBetweenMarkers(startId, endId);
   if (!range) return;
@@ -235,7 +242,7 @@ async function updateScripts(
     // ES modules don't have inline extra/before/after scripts — just load the src.
     if (isModule) {
       if (script.src) {
-        await insert(handle, { src: transformAssetUrl(script.src, instance), isModule: true });
+        await insert(handle, { src: resolveAssetHref(script.src, instance, ctx.wpHomeUrl, ctx.otherInstances), isModule: true });
       }
       continue;
     }
@@ -263,7 +270,7 @@ async function updateScripts(
     }
 
     if (script.src) {
-      await insert(handle, { src: transformAssetUrl(script.src, instance) });
+      await insert(handle, { src: resolveAssetHref(script.src, instance, ctx.wpHomeUrl, ctx.otherInstances) });
     }
 
     const afterScript = joinScriptContent(script.after);
@@ -339,6 +346,7 @@ function updateImportMap(
   imports: WPImport[] | null | undefined,
   instance: string,
   pathname: string,
+  ctx: AssetContext,
 ): void {
   const existing = document.getElementById('wp-importmap');
   if (existing) {
@@ -350,7 +358,7 @@ function updateImportMap(
   const map: Record<string, string> = {};
   for (const entry of imports) {
     // Paths use the RELATIVE scheme — route through the asset proxy.
-    map[entry.name] = transformAssetUrl(entry.path, instance);
+    map[entry.name] = resolveAssetHref(entry.path, instance, ctx.wpHomeUrl, ctx.otherInstances);
   }
 
   const el = document.createElement('script');
@@ -380,6 +388,19 @@ export function AssetUpdater({
   // pathname) re-fetches and re-applies assets.
   const hasMounted = useRef(false);
 
+  const assetContext = useMemo<AssetContext>(() => {
+    const { wpHomeUrl } = getWPInstance(instance);
+    const otherInstances = Object.entries(getAllWPInstances())
+      .reduce((acc, [slug, entry]) => {
+        if (entry.wpHomeUrl === wpHomeUrl) {
+          return acc;
+        }
+        acc[slug] = entry.wpHomeUrl;
+        return acc;
+      }, {} as Record<string, string>);
+    return { wpHomeUrl, otherInstances };
+  }, [instance]);
+
   useEffect(() => {
     if (!hasMounted.current) {
       hasMounted.current = true;
@@ -396,9 +417,9 @@ export function AssetUpdater({
         const assets = await fetchAssets(pathname);
         if (cancelled) return;
 
-        updateStylesheets(assets.stylesheets, instance);
+        updateStylesheets(assets.stylesheets, instance, assetContext);
         updateGlobalStyles(assets.globalStyles, instance, pathname);
-        updateImportMap(assets.importMap, instance, pathname);
+        updateImportMap(assets.importMap, instance, pathname, assetContext);
 
         // Insert head scripts sequentially, then body scripts sequentially,
         // so each script (inline or external) finishes executing before the
@@ -410,6 +431,7 @@ export function AssetUpdater({
           'nextpress-head-scripts-end',
           instance,
           pathname,
+          assetContext,
         );
         if (cancelled) return;
 
@@ -420,6 +442,7 @@ export function AssetUpdater({
           'nextpress-body-scripts-end',
           instance,
           pathname,
+          assetContext,
         );
         if (cancelled) return;
 
@@ -433,7 +456,7 @@ export function AssetUpdater({
     return () => {
       cancelled = true;
     };
-  }, [pathname, instance, fetchAssets]);
+  }, [pathname, instance, fetchAssets, assetContext]);
 
   return null;
 }

--- a/packages/js/src/Stylesheets/Stylesheets.tsx
+++ b/packages/js/src/Stylesheets/Stylesheets.tsx
@@ -6,7 +6,9 @@ import React, {
 import { preinit } from 'react-dom';
 
 import { EnqueuedStylesheet } from '@/types';
+import { getAllWPInstances, getWPInstance } from '@/config/getWPInstance';
 import { scopeInlineStyles } from '@/utils/scopeStyles';
+import { resolveAssetHref } from '@/utils/url';
 
 export interface StyleProps {
   id?: string;
@@ -23,35 +25,18 @@ export type StylesheetsProps = {
   pathname?: string;
 };
 
-/**
- * Extracts the path from a URL, removing the protocol and domain
- */
-function extractPath(url: string): string {
-  try {
-    const urlObj = new URL(url);
-    return urlObj.pathname;
-  } catch {
-    // If URL parsing fails, assume it's already a path
-    return url;
-  }
-}
-
-export function resolveStylesheetHref(src: string, instance: string): string {
-  const isInternalRoute = /^\/wp-(?:includes|admin)\//;
-  // Extract path from full URL if needed
-  const path = extractPath(src);
-
-  if (isInternalRoute.test(path)) {
-    // Internal WordPress path (e.g., /wp-includes/css/... or /wp-admin/css/...)
-    return `/atx/${instance}/wp-internal-assets${path}`;
-  } else {
-    // WordPress content path (e.g., /wp-content/...)
-    return `/atx/${instance}/wp-assets${path}`;
-  }
-}
+export const resolveStylesheetHref = resolveAssetHref;
 
 export function Stylesheets({ stylesheets, instance = 'default', pathname: _pathname = '' }: StylesheetsProps) {
-  
+  const { wpHomeUrl } = getWPInstance(instance);
+  const otherInstances = Object.entries(getAllWPInstances())
+    .reduce((acc, [slug, entry]) => {
+      if (entry.wpHomeUrl === wpHomeUrl) {
+        return acc;
+      }
+      acc[slug] = entry.wpHomeUrl;
+      return acc;
+    }, {} as Record<string, string>);
 
   return (
     <Fragment>
@@ -59,10 +44,9 @@ export function Stylesheets({ stylesheets, instance = 'default', pathname: _path
       {stylesheets.map((stylesheet) => {
         const { handle, src } = stylesheet;
 
-        // Determine the correct href for the stylesheet
         let href = '';
-         if (src) {
-          href = resolveStylesheetHref(src, instance);
+        if (src) {
+          href = resolveAssetHref(src, instance, wpHomeUrl, otherInstances);
           preinit(href, { as: 'style', precedence: handle as string });
         }
         const Link = 'link' as unknown as FC<JSX.IntrinsicElements['link'] & { precedence: string }>;

--- a/packages/js/src/utils/url.spec.ts
+++ b/packages/js/src/utils/url.spec.ts
@@ -1,4 +1,4 @@
-import { extractPath, isInternalRoute, isExternalScript, isScriptForAnotherInstance, transformAssetUrl } from './url';
+import { extractPath, isInternalRoute, isExternalScript, isScriptForAnotherInstance, resolveAssetHref, transformAssetUrl } from './url';
 
 describe('extractPath', () => {
   it('should extract pathname from a full URL', () => {
@@ -11,6 +11,11 @@ describe('extractPath', () => {
 
   it('should strip query string and hash', () => {
     expect(extractPath('http://example.com/file.js?ver=1.0#section')).toBe('/file.js');
+  });
+
+  it('should extract pathname from a protocol-relative URL', () => {
+    expect(extractPath('//wordpress.local/app/plugins/sub/assets/css/checkout.css'))
+      .toBe('/app/plugins/sub/assets/css/checkout.css');
   });
 });
 
@@ -51,6 +56,14 @@ describe('isExternalScript', () => {
   it('should return false for invalid URLs', () => {
     expect(isExternalScript('/relative/path.js', ['http://wordpress.local'])).toBe(false);
   });
+
+  it('should return false for a protocol-relative URL whose host matches the backend', () => {
+    expect(isExternalScript('//wordpress.local/app/plugins/test.js', ['http://wordpress.local'])).toBe(false);
+  });
+
+  it('should ignore scheme when matching backend host (http asset on https backend)', () => {
+    expect(isExternalScript('http://wordpress.local/app/plugins/test.js', ['https://wordpress.local'])).toBe(false);
+  });
 });
 
 describe('isScriptForAnotherInstance', () => {
@@ -73,6 +86,13 @@ describe('isScriptForAnotherInstance', () => {
       '/relative/path.js',
       { shop: 'http://other-site.local' }
     )).toBe(false);
+  });
+
+  it('should match a protocol-relative URL against a known instance', () => {
+    expect(isScriptForAnotherInstance(
+      '//other-site.local/app/plugins/test.js',
+      { shop: 'http://other-site.local' }
+    )).toBe('shop');
   });
 });
 
@@ -105,5 +125,55 @@ describe('transformAssetUrl', () => {
   it('should handle relative paths', () => {
     expect(transformAssetUrl('/wp-includes/js/test.js', 'default'))
       .toBe('/atx/default/wp-internal-assets/wp-includes/js/test.js');
+  });
+
+  it('should strip the host from a protocol-relative URL', () => {
+    expect(transformAssetUrl('//wordpress.local/app/plugins/woocommerce-subscriptions/assets/css/checkout.css', 'shop'))
+      .toBe('/atx/shop/wp-assets/app/plugins/woocommerce-subscriptions/assets/css/checkout.css');
+  });
+});
+
+describe('resolveAssetHref', () => {
+  const wpHomeUrl = 'http://wordpress.local';
+
+  it('should proxy a same-host URL through the current instance', () => {
+    expect(resolveAssetHref(
+      'http://wordpress.local/app/plugins/my-plugin/script.js',
+      'shop',
+      wpHomeUrl,
+      {},
+    )).toBe('/atx/shop/wp-assets/app/plugins/my-plugin/script.js');
+  });
+
+  it('should return external URLs unchanged with query string preserved', () => {
+    const googleFonts = 'https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;600;800&display=swap';
+    expect(resolveAssetHref(googleFonts, 'shop', wpHomeUrl, {})).toBe(googleFonts);
+  });
+
+  it('should route foreign-instance URLs through the matching instance proxy', () => {
+    expect(resolveAssetHref(
+      'http://other-site.local/app/plugins/my-plugin/script.js',
+      'shop',
+      wpHomeUrl,
+      { marketing: 'http://other-site.local' },
+    )).toBe('/atx/marketing/wp-assets/app/plugins/my-plugin/script.js');
+  });
+
+  it('should resolve a protocol-relative same-host URL via the current instance proxy', () => {
+    expect(resolveAssetHref(
+      '//wordpress.local/app/plugins/woocommerce-subscriptions/assets/css/checkout.css',
+      'shop',
+      wpHomeUrl,
+      {},
+    )).toBe('/atx/shop/wp-assets/app/plugins/woocommerce-subscriptions/assets/css/checkout.css');
+  });
+
+  it('should match host regardless of scheme (http asset on https backend)', () => {
+    expect(resolveAssetHref(
+      'http://wordpress.local/app/plugins/my-plugin/script.js',
+      'shop',
+      'https://wordpress.local',
+      {},
+    )).toBe('/atx/shop/wp-assets/app/plugins/my-plugin/script.js');
   });
 });

--- a/packages/js/src/utils/url.ts
+++ b/packages/js/src/utils/url.ts
@@ -1,10 +1,26 @@
 /**
+ * Normalize protocol-relative URLs so `new URL()` can parse them
+ * without a base argument. The placeholder scheme is only used to
+ * satisfy URL parsing — host comparison ignores it.
+ */
+function withScheme(url: string): string {
+  return url.startsWith('//') ? `http:${url}` : url;
+}
+
+function getHost(url: string): string | null {
+  try {
+    return new URL(withScheme(url)).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Extracts the path from a URL, removing the protocol and domain.
  */
 export function extractPath(url: string): string {
   try {
-    const urlObj = new URL(url);
-    return urlObj.pathname;
+    return new URL(withScheme(url)).pathname;
   } catch {
     return url;
   }
@@ -16,30 +32,31 @@ export function extractPath(url: string): string {
 export const isInternalRoute = /^\/wp-(?:includes|admin)\//;
 
 /**
- * Determines if a script URL is external (different origin) or a WordPress asset.
+ * Determines if a script URL is external (different host) or a WordPress asset.
  * External scripts should be loaded directly, WordPress assets should be proxied.
+ *
+ * Compares by host instead of origin so protocol-relative URLs and scheme
+ * mismatches (e.g. http asset on an https page) still classify correctly.
  */
 export function isExternalScript(scriptUrl: string, instanceHomeUrls: string[]): boolean {
-  try {
-    const scriptOrigin = new URL(scriptUrl).origin;
-    return !instanceHomeUrls.some(url => new URL(url).origin === scriptOrigin);
-  } catch {
+  const scriptHost = getHost(scriptUrl);
+  if (scriptHost === null) {
     return false;
   }
+  return !instanceHomeUrls.some(url => getHost(url) === scriptHost);
 }
 
 export function isScriptForAnotherInstance(scriptUrl: string, instances: Record<string, string>): string | false {
-  try {
-    const scriptOrigin = new URL(scriptUrl).origin;
-    for (const [slug, url] of Object.entries(instances)) {
-      if (new URL(url).origin === scriptOrigin) {
-        return slug;
-      }
-    }
-    return false;
-  } catch {
+  const scriptHost = getHost(scriptUrl);
+  if (scriptHost === null) {
     return false;
   }
+  for (const [slug, url] of Object.entries(instances)) {
+    if (getHost(url) === scriptHost) {
+      return slug;
+    }
+  }
+  return false;
 }
 
 /**
@@ -51,4 +68,27 @@ export function transformAssetUrl(src: string, instance: string): string {
   const path = extractPath(src);
   const prefix = isInternalRoute.test(path) ? 'wp-internal-assets' : 'wp-assets';
   return `/atx/${instance}/${prefix}${path}`;
+}
+
+/**
+ * Resolves the final href for a WordPress asset, choosing between:
+ * - A foreign-instance proxy when the URL belongs to a known other instance.
+ * - The original src when the URL points to a non-WordPress origin (CDNs,
+ *   payment gateways, web fonts).
+ * - The current instance's proxy otherwise.
+ */
+export function resolveAssetHref(
+  src: string,
+  instance: string,
+  wpHomeUrl: string,
+  otherInstances: Record<string, string>,
+): string {
+  const foreignSlug = isScriptForAnotherInstance(src, otherInstances);
+  if (foreignSlug) {
+    return transformAssetUrl(src, foreignSlug);
+  }
+  if (isExternalScript(src, [wpHomeUrl, ...Object.values(otherInstances)])) {
+    return src;
+  }
+  return transformAssetUrl(src, instance);
 }

--- a/packages/wordpress/includes/class-assets.php
+++ b/packages/wordpress/includes/class-assets.php
@@ -34,6 +34,8 @@ class Assets {
 
 		add_filter( 'woocommerce_store_api_disable_nonce_check', array( $this, 'disable_wc_nonce_check' ) );
 
+		add_filter( 'nextpress/graphql/uri-assets/skip_script_module_dependency', array( $this, 'skip_unbootstrapped_wc_handles' ), 10, 4 );
+
 		// Transform WooCommerce Stripe Gateway Express Checkout params
 		add_filter( 'wc_stripe_express_checkout_params', array( $this, 'transform_stripe_express_checkout_params' ) );
 		add_filter( 'wc_stripe_upe_params', array( $this, 'transform_stripe_express_checkout_params' ) );
@@ -314,6 +316,63 @@ class Assets {
 			&& $settings['enable_custom_wc_scripts'] === 'on';
 
 		return $is_enabled;
+	}
+
+	/**
+	 * Skip enqueued script handles whose runtime depends on Store API
+	 * extension data that only registers when the upstream plugin's TOS
+	 * / connection flow has run.
+	 *
+	 * `woocommerce-services-store-notices` reads
+	 * `cart.extensions["woocommerce-services"].notices` and crashes when
+	 * the key is missing. WC Services only registers that extension if
+	 * `tos_accepted` is true inside `WC_Connect_Loader::after_wc_init`,
+	 * so when TOS hasn't been accepted the script loads with no data to
+	 * read.
+	 *
+	 * @param string|false     $handle               Current handle being walked.
+	 * @param array            $queue                The flatten queue.
+	 * @param \WP_Dependencies $wp_assets            Active assets registry.
+	 * @param bool             $check_script_modules Whether modules are being walked.
+	 * @return string|false The handle, or false to drop it from the asset list.
+	 */
+	public function skip_unbootstrapped_wc_handles( $handle, $queue, $wp_assets, $check_script_modules ) {
+		$settings   = get_option( 'nextpress_headless_settings', array() );
+		$is_enabled = isset( $settings['enable_custom_wc_scripts'] )
+			&& $settings['enable_custom_wc_scripts'] === 'on';
+
+		if ( ! $is_enabled ) {
+			return $handle;
+		}
+
+		if ( 'woocommerce-services-store-notices' === $handle && ! $this->wc_services_tos_accepted() ) {
+			return false;
+		}
+
+		return $handle;
+	}
+
+	/**
+	 * Read the WC Services TOS-accepted flag.
+	 *
+	 * Prefers the upstream `WC_Connect_Options` accessor when WCS is
+	 * loaded; falls back to reading the underlying `wc_connect_options`
+	 * grouped option directly so this works even if WCS hasn't booted
+	 * far enough to expose its class.
+	 *
+	 * @return bool
+	 */
+	protected function wc_services_tos_accepted(): bool {
+		if ( class_exists( 'WC_Connect_Options' ) ) {
+			return (bool) \WC_Connect_Options::get_option( 'tos_accepted' );
+		}
+
+		$options = get_option( 'wc_connect_options' );
+		if ( is_array( $options ) && ! empty( $options['tos_accepted'] ) ) {
+			return true;
+		}
+
+		return (bool) get_option( 'wc_connect_tos_accepted', false );
 	}
 
 	/**

--- a/packages/wordpress/includes/graphql/utils/class-wp-assets.php
+++ b/packages/wordpress/includes/graphql/utils/class-wp-assets.php
@@ -31,13 +31,22 @@ class WP_Assets {
 			if ( 'global-styles' === $handle ) {
 				continue;
 			}
+
+			$handle = apply_filters(
+				'nextpress/graphql/uri-assets/skip_script_module_dependency',
+				$handle,
+				$queue,
+				$wp_assets,
+				$check_script_modules
+			);
+			if ( ! $handle ) {
+				continue;
+			}
+
 			if ( ! empty( $registered_scripts[ $handle ] ) ) {
 				/** @var \_WP_Dependency $script */
-				$script    = $registered_scripts[ $handle ];
-				$handles[] = $script->handle;
+				$script = $registered_scripts[ $handle ];
 
-				// Don't recurse into MODULE dependencies — those are resolved
-				// by the browser's import map, not by <script> tags.
 				$is_module = isset( $script->extra['type'] ) && 'module' === $script->extra['type'];
 				if ( ! $is_module ) {
 					$formatted_dependencies = array_map(
@@ -45,11 +54,20 @@ class WP_Assets {
 						(array) ( $script->deps ?? [] )
 					);
 					$dependencies = self::flatten_enqueued_assets_list( $formatted_dependencies, $wp_assets, $check_script_modules );
-					if ( ! empty( $dependencies ) ) {
-						array_unshift( $handles, ...$dependencies );
+					
+					$dependencies = apply_filters(
+						'nextpress/graphql/uri-assets/script_dependencies',
+						$dependencies,
+						$handle,
+						$script
+					);
+
+					foreach ( $dependencies as $dep ) {
+						$handles[] = $dep;
 					}
 				}
 
+				$handles[] = $script->handle;
 				continue;
 			}
 
@@ -57,13 +75,10 @@ class WP_Assets {
 				continue;
 			}
 
-			// Check if it's in the script modules registry.
 			$all_modules = class_exists( NextPress_Script_Modules::class ) ? NextPress_Script_Modules::get_registered_modules() : [];
 			if ( isset( $all_modules[ $handle ] ) ) {
 				$module_data = $all_modules[ $handle ];
-				$handles[]   = $handle;
 
-				// Collect module dependency IDs and recurse.
 				$module_deps = [];
 				foreach ( (array) ( $module_data['dependencies'] ?? [] ) as $dep ) {
 					if ( is_array( $dep ) && isset( $dep['id'] ) ) {
@@ -75,12 +90,20 @@ class WP_Assets {
 
 				if ( ! empty( $module_deps ) ) {
 					$dependencies = self::flatten_enqueued_assets_list( $module_deps, $wp_assets, $check_script_modules );
-					if ( ! empty( $dependencies ) ) {
-						array_unshift( $handles, ...$dependencies );
+					$dependencies = apply_filters(
+						'nextpress/graphql/uri-assets/script_module_dependencies',
+						$dependencies,
+						$handle,
+						$module_data
+					);
+
+					foreach ( $dependencies as $dep ) {
+						$handles[] = $dep;
 					}
 				}
-			}
 
+				$handles[] = $handle;
+			}
 		}
 
 		return array_values( array_unique( $handles ) );


### PR DESCRIPTION
## Summary

- **nextpress (js)**: External asset URLs (Google Fonts, CDNs) are now preserved with their query strings instead of being stripped and routed through the WP asset proxy. Protocol-relative URLs (`//host/path`, common in WC enqueues via `set_url_scheme()`) are parsed correctly so the host is no longer pasted into the rewritten path. WP instance matching switched to host comparison so scheme mismatches still resolve. New shared `resolveAssetHref` helper consolidates the foreign-instance / external / current-instance branching across `Stylesheets`, `AssetUpdater` (`updateStylesheets`, `updateScripts`, `updateImportMap`).
- **nextpress-wordpress**: `WP_Assets::flatten_enqueued_assets_list` now appends each resolved dependency just before its dependent, instead of `array_unshift`-ing all dependencies to the very front of the handles array. The old behavior front-loaded deps regardless of which queue items needed them, breaking relative ordering for scripts that rely on implicit load order (`wc-order-attribution` loading after `wc-stripe-blocks-integration` caused `setOrderTracking is not a function`). New `Assets::skip_unbootstrapped_wc_handles` callback on `nextpress/graphql/uri-assets/skip_script_module_dependency` drops `woocommerce-services-store-notices` when WCS' `tos_accepted` is false (the WCS Store API extension that populates `cart.extensions["woocommerce-services"]` never registers without TOS, so the script crashes on US-address checkouts). Gated on the existing `enable_custom_wc_scripts` setting.

## Test plan

- [x] `npm run test` in `packages/js` — 125 tests across 7 suites pass, 7 new url.spec.ts cases lock in protocol-relative + external-host + scheme-mismatch handling and the three-way `resolveAssetHref` branching.
- [x] `npm run typecheck` in `packages/js` — clean.
- [x] Verify on a headless WP setup that:
  - Google Fonts `<link>` tags render with the full `https://fonts.googleapis.com/css2?family=...` URL (query string preserved) and load 200 directly from the origin.
  - WC Subscriptions' `wcs-checkout` stylesheet (`//host/app/plugins/woocommerce-subscriptions/.../checkout.css`) resolves to `/atx/{instance}/wp-assets/app/plugins/woocommerce-subscriptions/.../checkout.css` and serves 200.
  - WC Stripe blocks load without the `setOrderTracking is not a function` error on `/checkout`.
  - On a backend with `tos_accepted` false in `wc_connect_options`, `woocommerce-services-store-notices` is absent from the `assetsByUri` response and the `Cannot read properties of undefined (reading 'notices')` PluginErrorBoundary crash is gone.