### PR TITLE
fix: route Stripe localized WP URLs through correct proxy aliases

### DIFF
--- a/.changeset/headless-wp-ajax-stripe-url-mapping.md
+++ b/.changeset/headless-wp-ajax-stripe-url-mapping.md
@@ -3,7 +3,7 @@
 "@axistaylor/nextpress-wordpress": patch
 ---
 
-Route WP-internal URLs in Stripe localized params through the correct proxy aliases, installation-agnostic.
+Route WP-internal URLs in Stripe localized params through the correct proxy aliases, and stop re-executing external scripts across client-side navigation. Installation-agnostic.
 
 **`@axistaylor/nextpress-wordpress`**
 
@@ -22,4 +22,6 @@ This fixes Stripe UPE Classic's admin-ajax call from `wp_ajax_url` (which previo
 
 **`@axistaylor/nextpress`**
 
-`replaceProxyPlaceholders` no longer concatenates the current page pathname into the frontend origin when expanding `__NEXTPRESS_PROXY__`. Previously `frontendOrigin = ${wcr_frontend_url}/${pathname}`, so on a page like `/account/add-payment-method` every `__NEXTPRESS_PROXY__` got replaced with `${origin}//account/add-payment-method` (note the double slash + injected path segment), corrupting every WP-emitted absolute URL routed through that placeholder. The `pathname` argument is kept in the signature for back-compat with existing callers but is now unused.
+- `replaceProxyPlaceholders` no longer concatenates the current page pathname into the frontend origin when expanding `__NEXTPRESS_PROXY__`. Previously `frontendOrigin = ${wcr_frontend_url}/${pathname}`, so on a page like `/account/add-payment-method` every `__NEXTPRESS_PROXY__` got replaced with `${origin}//account/add-payment-method` (note the double slash + injected path segment), corrupting every WP-emitted absolute URL routed through that placeholder. The `pathname` argument is kept in the signature for back-compat with existing callers but is now unused.
+
+- `AssetUpdater` now dedupes external `<script src>` insertions across the session via a module-level `Set` of already-loaded src URLs, seeded from any scripts already in the DOM between the markers on first run. Removing a `<script>` from the DOM does not undo its side-effects (globals it defined, custom elements it registered), so re-inserting the same external src on a subsequent client-side navigation would re-run its IIFE and break anything non-idempotent. The trigger in practice was `wc-order-attribution`'s `customElements.define('wc-order-attribution-inputs', …)` throwing `NotSupportedError: the name … has already been used with this registry` on the second navigation. Inline `extraData` / `before` / `after` blocks still run on every navigation since they typically carry page-specific data.

--- a/.changeset/headless-wp-ajax-stripe-url-mapping.md
+++ b/.changeset/headless-wp-ajax-stripe-url-mapping.md
@@ -1,0 +1,25 @@
+---
+"@axistaylor/nextpress": patch
+"@axistaylor/nextpress-wordpress": patch
+---
+
+Route WP-internal URLs in Stripe localized params through the correct proxy aliases, installation-agnostic.
+
+**`@axistaylor/nextpress-wordpress`**
+
+`Assets::transform_stripe_params_urls` now maps each detected WordPress URL to the proxy-route alias it belongs to, before client-side replacement. Previously every WP URL got the same `__NEXTPRESS_ASSETS__/<original-path>` placeholder, producing client URLs like `/atx/<instance>/wp/wp-admin/admin-ajax.php` that match no proxy matcher. New mappings (path is now stripped of any `site_url` subdirectory first, so behavior is identical for root and subdirectory WP installs):
+
+| Detected WP URL | Emitted placeholder |
+| --- | --- |
+| `…/wp-admin/admin-ajax.php` | `__NEXTPRESS_ASSETS__/wp` (+ query) |
+| `?wc-ajax=…` on home_url | `__NEXTPRESS_ASSETS__/wc?wc-ajax=…` |
+| `…/wp-(admin\|includes)/…` static | `__NEXTPRESS_ASSETS__/wp-internal-assets/…` |
+| `…/wp-content/…` | `__NEXTPRESS_ASSETS__/wp-assets/…` |
+| `…/wp-json/…` | `__NEXTPRESS_ASSETS__/wp-json/…` |
+| anything else on home_url | `__NEXTPRESS_PROXY__<path>` |
+
+This fixes Stripe UPE Classic's admin-ajax call from `wp_ajax_url` (which previously hit the headless app at `/<page-path>/wp/wp-admin/admin-ajax.php` and 500'd) so SetupIntent creation, payment-intent updates, and other WC Stripe AJAX endpoints reach the WP backend through `proxyByWCR`'s body-forwarding `/wp` and `/wc` short aliases.
+
+**`@axistaylor/nextpress`**
+
+`replaceProxyPlaceholders` no longer concatenates the current page pathname into the frontend origin when expanding `__NEXTPRESS_PROXY__`. Previously `frontendOrigin = ${wcr_frontend_url}/${pathname}`, so on a page like `/account/add-payment-method` every `__NEXTPRESS_PROXY__` got replaced with `${origin}//account/add-payment-method` (note the double slash + injected path segment), corrupting every WP-emitted absolute URL routed through that placeholder. The `pathname` argument is kept in the signature for back-compat with existing callers but is now unused.

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -14,6 +14,22 @@ export interface AssetData {
   importMap?: WPImport[] | null;
 }
 
+/**
+ * External script srcs already loaded in this browser session. Removing
+ * a `<script>` element from the DOM does NOT undo its side effects — any
+ * globals it defined and any `customElements.define()` calls it made
+ * persist. Re-inserting the same external src on the next navigation
+ * therefore re-runs the IIFE and breaks anything non-idempotent
+ * (e.g. wc-order-attribution throws `NotSupportedError: the name
+ * "wc-order-attribution-inputs" has already been used`).
+ *
+ * Session-scoped (lives for the lifetime of the page) so navigation
+ * between many WP-instance pages doesn't accumulate forever in practice.
+ * Cleared automatically on full page reload.
+ */
+const loadedExternalSrcs = new Set<string>();
+
+
 export interface AssetUpdaterProps {
   /**
    * The current pathname being rendered.
@@ -178,6 +194,27 @@ async function updateScripts(
   instance: string,
   pathname: string,
 ): Promise<void> {
+  // Seed the dedupe set from scripts currently between the markers
+  // before clearing. Server-rendered scripts (initial page load) and
+  // scripts inserted by a previous AssetUpdater run have both already
+  // executed — their side effects are in JS land regardless of whether
+  // their <script> element still exists in the DOM. Comparing on the
+  // raw src attribute matches how we insert new scripts below.
+  const startSeed = document.getElementById(startId);
+  const endSeed = document.getElementById(endId);
+  if (startSeed && endSeed) {
+    let node: ChildNode | null = startSeed.nextSibling;
+    while (node && node !== endSeed) {
+      if (node instanceof HTMLScriptElement) {
+        const seedSrc = node.getAttribute('src');
+        if (seedSrc) {
+          loadedExternalSrcs.add(seedSrc);
+        }
+      }
+      node = node.nextSibling;
+    }
+  }
+
   const range = clearBetweenMarkers(startId, endId);
   if (!range) return;
 
@@ -235,7 +272,11 @@ async function updateScripts(
     // ES modules don't have inline extra/before/after scripts — just load the src.
     if (isModule) {
       if (script.src) {
-        await insert(handle, { src: transformAssetUrl(script.src, instance), isModule: true });
+        const src = transformAssetUrl(script.src, instance);
+        if (!loadedExternalSrcs.has(src)) {
+          loadedExternalSrcs.add(src);
+          await insert(handle, { src, isModule: true });
+        }
       }
       continue;
     }
@@ -263,7 +304,11 @@ async function updateScripts(
     }
 
     if (script.src) {
-      await insert(handle, { src: transformAssetUrl(script.src, instance) });
+      const src = transformAssetUrl(script.src, instance);
+      if (!loadedExternalSrcs.has(src)) {
+        loadedExternalSrcs.add(src);
+        await insert(handle, { src });
+      }
     }
 
     const afterScript = joinScriptContent(script.after);

--- a/packages/js/src/compatibility/woocommerce.spec.ts
+++ b/packages/js/src/compatibility/woocommerce.spec.ts
@@ -1,0 +1,141 @@
+import { replaceProxyPlaceholders } from './woocommerce';
+
+describe('replaceProxyPlaceholders', () => {
+  const ORIGINAL_FRONTEND_URL = process.env.wcr_frontend_url;
+
+  beforeEach(() => {
+    process.env.wcr_frontend_url = 'http://localhost:3000';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_FRONTEND_URL === undefined) {
+      delete process.env.wcr_frontend_url;
+    } else {
+      process.env.wcr_frontend_url = ORIGINAL_FRONTEND_URL;
+    }
+  });
+
+  describe('empty / unchanged inputs', () => {
+    it('returns empty content unchanged', () => {
+      expect(replaceProxyPlaceholders('', 'default')).toBe('');
+    });
+
+    it('returns content with no placeholders unchanged', () => {
+      const input = 'var foo = { bar: "baz" };';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(input);
+    });
+  });
+
+  describe('__NEXTPRESS_PROXY__ replacement', () => {
+    it('replaces the placeholder with frontend origin (unescaped slashes)', () => {
+      const input = 'var url = "http://__NEXTPRESS_PROXY__/checkout/";';
+      const expected = 'var url = "http://localhost:3000/checkout/";';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+
+    it('replaces the placeholder with frontend origin (JSON-escaped slashes)', () => {
+      const input = '{"url":"http:\\/\\/__NEXTPRESS_PROXY__\\/checkout\\/"}';
+      const expected = '{"url":"http:\\/\\/localhost:3000\\/checkout\\/"}';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+
+    it('does NOT inject the current page pathname into the frontend origin', () => {
+      // Regression test: previously frontendOrigin was `${url}/${pathname}`,
+      // producing URLs like `http://localhost:3000//account/checkout/`.
+      const input = 'var url = "http://__NEXTPRESS_PROXY__/checkout/";';
+      const result = replaceProxyPlaceholders(input, 'default', '/account/add-payment-method');
+      expect(result).toBe('var url = "http://localhost:3000/checkout/";');
+      expect(result).not.toContain('//account');
+      expect(result).not.toContain('/add-payment-method/checkout');
+    });
+
+    it('handles multiple occurrences in one string', () => {
+      const input = 'a=http://__NEXTPRESS_PROXY__/cart/; b=http://__NEXTPRESS_PROXY__/checkout/;';
+      const expected = 'a=http://localhost:3000/cart/; b=http://localhost:3000/checkout/;';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+
+    it('matches https placeholder and substitutes frontend origin scheme', () => {
+      // The regex matches both http:// and https:// placeholders, but the
+      // substitution uses the scheme of `wcr_frontend_url`. Behavior is
+      // intentional: callers should set wcr_frontend_url to whichever
+      // scheme the frontend serves on.
+      const input = 'var url = "https://__NEXTPRESS_PROXY__/checkout/";';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe('var url = "http://localhost:3000/checkout/";');
+      process.env.wcr_frontend_url = 'https://example.com';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe('var url = "https://example.com/checkout/";');
+    });
+
+    it('falls back to empty origin when wcr_frontend_url is unset', () => {
+      delete process.env.wcr_frontend_url;
+      const input = 'var url = "http://__NEXTPRESS_PROXY__/checkout/";';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe('var url = "/checkout/";');
+    });
+
+    it('ignores the deprecated pathname argument (does not affect output)', () => {
+      const input = 'var url = "http://__NEXTPRESS_PROXY__/cart/";';
+      const without = replaceProxyPlaceholders(input, 'default');
+      const withSlash = replaceProxyPlaceholders(input, 'default', '/some-page');
+      const withoutSlash = replaceProxyPlaceholders(input, 'default', 'some-page');
+      expect(without).toBe(withSlash);
+      expect(without).toBe(withoutSlash);
+    });
+  });
+
+  describe('__NEXTPRESS_ASSETS__ replacement', () => {
+    it('replaces the placeholder with /atx/<instance> (unescaped slashes)', () => {
+      const input = 'var url = "http://__NEXTPRESS_ASSETS__/wp-content/plugins/foo.js";';
+      const expected = 'var url = "/atx/default/wp-content/plugins/foo.js";';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+
+    it('replaces the placeholder with /atx/<instance> (JSON-escaped slashes)', () => {
+      const input = '{"src":"http:\\/\\/__NEXTPRESS_ASSETS__\\/wp-content\\/plugins\\/foo.js"}';
+      const expected = '{"src":"\\/atx\\/default\\/wp-content\\/plugins\\/foo.js"}';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+
+    it('preserves the path that follows the placeholder', () => {
+      // Path-based routing is determined by the PHP layer (which writes
+      // the placeholder with the right proxy-route alias path baked in,
+      // e.g. /wp, /wc, /wp-internal-assets/..., /wp-assets/...). The TS
+      // replacement must not alter that path.
+      const cases = [
+        ['http://__NEXTPRESS_ASSETS__/wp', '/atx/shop/wp'],
+        ['http://__NEXTPRESS_ASSETS__/wc?wc-ajax=add_to_cart', '/atx/shop/wc?wc-ajax=add_to_cart'],
+        ['http://__NEXTPRESS_ASSETS__/wp-internal-assets/wp-admin/load-styles.php?ver=1', '/atx/shop/wp-internal-assets/wp-admin/load-styles.php?ver=1'],
+        ['http://__NEXTPRESS_ASSETS__/wp-assets/wp-content/plugins/foo.js', '/atx/shop/wp-assets/wp-content/plugins/foo.js'],
+        ['http://__NEXTPRESS_ASSETS__/wp-json/wc/store/v1/cart', '/atx/shop/wp-json/wc/store/v1/cart'],
+      ];
+      for (const [input, expected] of cases) {
+        expect(replaceProxyPlaceholders(input, 'shop')).toBe(expected);
+      }
+    });
+
+    it('uses the supplied instance slug', () => {
+      const input = 'var url = "http://__NEXTPRESS_ASSETS__/wp";';
+      expect(replaceProxyPlaceholders(input, 'shop')).toBe('var url = "/atx/shop/wp";');
+      expect(replaceProxyPlaceholders(input, 'marketing')).toBe('var url = "/atx/marketing/wp";');
+    });
+
+    it('handles multiple occurrences in one string', () => {
+      const input = 'a=http://__NEXTPRESS_ASSETS__/wp; b=http://__NEXTPRESS_ASSETS__/wc?wc-ajax=foo;';
+      const expected = 'a=/atx/default/wp; b=/atx/default/wc?wc-ajax=foo;';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+  });
+
+  describe('mixed placeholders', () => {
+    it('handles both placeholder types in the same string', () => {
+      const input = 'page="http://__NEXTPRESS_PROXY__/checkout/"; ajax="http://__NEXTPRESS_ASSETS__/wp";';
+      const expected = 'page="http://localhost:3000/checkout/"; ajax="/atx/default/wp";';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+
+    it('handles mixed escaped + unescaped forms', () => {
+      const input = 'a=http://__NEXTPRESS_PROXY__/cart/; b="http:\\/\\/__NEXTPRESS_PROXY__\\/checkout\\/"';
+      const expected = 'a=http://localhost:3000/cart/; b="http:\\/\\/localhost:3000\\/checkout\\/"';
+      expect(replaceProxyPlaceholders(input, 'default')).toBe(expected);
+    });
+  });
+});

--- a/packages/js/src/compatibility/woocommerce.ts
+++ b/packages/js/src/compatibility/woocommerce.ts
@@ -14,12 +14,12 @@
  * @param instance - WordPress instance slug for proxy route
  * @returns String with placeholders replaced
  */
-export function replaceProxyPlaceholders(content: string, instance: string, pathname: string): string {
+export function replaceProxyPlaceholders(content: string, instance: string, _pathname?: string): string {
   if (!content) {
     return content;
   }
 
-  const frontendOrigin = `${(process.env.wcr_frontend_url || '')}/${pathname}`;
+  const frontendOrigin = process.env.wcr_frontend_url || '';
   const proxyRouteBase = `/atx/${instance}`;
 
   let result = content;

--- a/packages/wordpress/includes/class-assets.php
+++ b/packages/wordpress/includes/class-assets.php
@@ -448,46 +448,82 @@ class Assets {
 		}
 
 		if ( \is_string( $value ) ) {
-			// Parse URLs to get hosts for comparison
+			// Parse URLs to get hosts/paths for comparison.
 			$home_parsed = wp_parse_url( $home_url );
 			$site_parsed = wp_parse_url( $site_url );
 
 			$home_host = isset( $home_parsed['host'] ) ? $home_parsed['host'] : '';
 			$site_host = isset( $site_parsed['host'] ) ? $site_parsed['host'] : '';
 
-			// Check if the string contains a WordPress URL
+			// site_url's path is the WordPress install subdirectory
+			// (e.g. `/wp` on a Bedrock setup, empty on a root install).
+			// We strip it so the emitted placeholder path is always relative
+			// to the WP root — installation-agnostic.
+			$site_path = isset( $site_parsed['path'] ) ? rtrim( $site_parsed['path'], '/' ) : '';
+
 			$parsed = wp_parse_url( $value );
 
 			if ( ! isset( $parsed['host'] ) ) {
 				return $value;
 			}
 
-			// Check if URL is from our WordPress installation
-			$is_wp_url = ( $parsed['host'] === $home_host || $parsed['host'] === $site_host );
+			$is_site_url = ( $parsed['host'] === $site_host );
+			$is_home_url = ( $parsed['host'] === $home_host );
 
-			if ( ! $is_wp_url ) {
+			if ( ! $is_site_url && ! $is_home_url ) {
 				return $value;
 			}
 
-			// Determine the path
-			$path = isset( $parsed['path'] ) ? $parsed['path'] : '';
+			$path         = isset( $parsed['path'] ) ? $parsed['path'] : '';
+			$query_string = isset( $parsed['query'] ) ? $parsed['query'] : '';
 
-			// Check if this is an asset URL (wp-content, wp-includes, wp-admin)
-			$is_asset_url = preg_match( '/^\/wp-(?:content|includes|admin)\//', $path );
-
-			// Get the scheme
-			$scheme = isset( $parsed['scheme'] ) ? $parsed['scheme'] : 'http';
-
-			// Build query string if present
-			$query = isset( $parsed['query'] ) ? '?' . $parsed['query'] : '';
-
-			if ( $is_asset_url ) {
-				// Asset URL → use __NEXTPRESS_ASSETS__ placeholder
-				return "{$scheme}://__NEXTPRESS_ASSETS__{$path}{$query}";
-			} else {
-				// Page URL → use __NEXTPRESS_PROXY__ placeholder
-				return "{$scheme}://__NEXTPRESS_PROXY__{$path}{$query}";
+			// Normalize path: when targeting site_url, strip the install
+			// subdirectory so $path is relative to the WP root.
+			if ( $is_site_url && '' !== $site_path && 0 === strpos( $path, $site_path . '/' ) ) {
+				$path = substr( $path, strlen( $site_path ) );
 			}
+
+			$scheme = isset( $parsed['scheme'] ) ? $parsed['scheme'] : 'http';
+			$query  = '' !== $query_string ? '?' . $query_string : '';
+
+			// Map the WP URL to the appropriate proxy route alias inside the
+			// __NEXTPRESS_ASSETS__ placeholder. Client-side replacement just
+			// swaps the placeholder host for `/atx/<instance>` — no path
+			// rewriting needed on that side.
+
+			// wc-ajax — identified by `wc-ajax=` in the query. Routes to the
+			// `/wc` proxy alias which fetches `${wpHomeUrl}/?<query>` with
+			// proper method/headers/body forwarding.
+			if ( '' !== $query_string && preg_match( '/(?:^|&)wc-ajax=/', $query_string ) ) {
+				return "{$scheme}://__NEXTPRESS_ASSETS__/wc{$query}";
+			}
+
+			// admin-ajax.php — routes to the `/wp` proxy alias which fetches
+			// `${wpSiteUrl}/wp-admin/admin-ajax.php` with body forwarding
+			// (needed for AJAX POSTs).
+			if ( preg_match( '#/wp-admin/admin-ajax\.php$#', $path ) ) {
+				return "{$scheme}://__NEXTPRESS_ASSETS__/wp{$query}";
+			}
+
+			// wp-admin / wp-includes static assets — route through
+			// `/wp-internal-assets` which rewrites to `${wpSiteUrl}/<path>`.
+			if ( preg_match( '#^/wp-(?:admin|includes)/#', $path ) ) {
+				return "{$scheme}://__NEXTPRESS_ASSETS__/wp-internal-assets{$path}{$query}";
+			}
+
+			// wp-content assets — route through `/wp-assets` which rewrites
+			// to `${wpHomeUrl}/<path>`.
+			if ( preg_match( '#^/wp-content/#', $path ) ) {
+				return "{$scheme}://__NEXTPRESS_ASSETS__/wp-assets{$path}{$query}";
+			}
+
+			// REST API — route through the wp-json proxy.
+			if ( preg_match( '#^/wp-json/#', $path ) ) {
+				return "{$scheme}://__NEXTPRESS_ASSETS__{$path}{$query}";
+			}
+
+			// Anything else — public-facing page URL on home_url.
+			return "{$scheme}://__NEXTPRESS_PROXY__{$path}{$query}";
 		}
 
 		// Return non-string, non-array values unchanged

--- a/packages/wordpress/tests/Integration/AssetsStripeUrlTransformTest.php
+++ b/packages/wordpress/tests/Integration/AssetsStripeUrlTransformTest.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Tests the `Assets::transform_stripe_params_urls` URL → placeholder mapping
+ * used by the `wc_stripe_*_params` filters in headless setups.
+ *
+ * @package NextPress\Tests\Integration
+ */
+
+namespace Tests\Integration;
+
+use NextPress\Assets;
+use ReflectionMethod;
+use Tests\Support\NextPressTestCase;
+
+/**
+ * Class AssetsStripeUrlTransformTest
+ *
+ * Asserts each WP URL shape maps to the correct proxy-route alias inside
+ * the `__NEXTPRESS_ASSETS__` placeholder, and that page URLs on home_url
+ * still use the `__NEXTPRESS_PROXY__` placeholder. The mapping must be
+ * installation-agnostic — subdirectory installs (e.g. site_url at /wp)
+ * must produce the same placeholder paths as root installs.
+ */
+class AssetsStripeUrlTransformTest extends NextPressTestCase
+{
+    /**
+     * Invoke the private `transform_stripe_params_urls` method directly so
+     * we can unit-test the URL-mapping logic without needing the
+     * `enable_stripe_url_transforms` option + `is_graphql_request()` gates
+     * around the public entry point.
+     *
+     * @param mixed  $value    Value passed to the transform.
+     * @param string $home_url WordPress home_url.
+     * @param string $site_url WordPress site_url.
+     * @return mixed
+     */
+    private function invokeTransform($value, string $home_url, string $site_url)
+    {
+        $assets = new Assets();
+        $method = new ReflectionMethod(Assets::class, 'transform_stripe_params_urls');
+        $method->setAccessible(true);
+        return $method->invoke($assets, $value, $home_url, $site_url);
+    }
+
+    /**
+     * Helper: assert mapping with both root install and a /wp subdir install
+     * produce the same placeholder output. Validates installation agnosticism.
+     *
+     * @param string $expected            Expected output placeholder URL.
+     * @param string $root_install_url    WP URL on a root install.
+     * @param string $subdir_install_url  WP URL on a /wp subdir install.
+     */
+    private function assertMapping(string $expected, string $root_install_url, string $subdir_install_url): void
+    {
+        $home = 'http://example.com';
+
+        // Root install: home_url == site_url.
+        $this->assertSame(
+            $expected,
+            $this->invokeTransform($root_install_url, $home, $home),
+            'Root install mapping failed'
+        );
+
+        // Subdir install: site_url = home_url + /wp.
+        $this->assertSame(
+            $expected,
+            $this->invokeTransform($subdir_install_url, $home, $home . '/wp'),
+            'Subdirectory install mapping failed'
+        );
+    }
+
+    public function testAdminAjaxMapsToWpAlias(): void
+    {
+        $this->assertMapping(
+            'http://__NEXTPRESS_ASSETS__/wp',
+            'http://example.com/wp-admin/admin-ajax.php',
+            'http://example.com/wp/wp-admin/admin-ajax.php'
+        );
+    }
+
+    public function testAdminAjaxPreservesQuery(): void
+    {
+        $this->assertMapping(
+            'http://__NEXTPRESS_ASSETS__/wp?action=rest-nonce',
+            'http://example.com/wp-admin/admin-ajax.php?action=rest-nonce',
+            'http://example.com/wp/wp-admin/admin-ajax.php?action=rest-nonce'
+        );
+    }
+
+    public function testWcAjaxMapsToWcAliasAndPreservesQuery(): void
+    {
+        $home = 'http://example.com';
+
+        // wc-ajax URLs sit on home_url, not site_url, and are identified by
+        // the wc-ajax= query param.
+        $this->assertSame(
+            'http://__NEXTPRESS_ASSETS__/wc?wc-ajax=add_to_cart',
+            $this->invokeTransform('http://example.com/?wc-ajax=add_to_cart', $home, $home)
+        );
+
+        $this->assertSame(
+            'http://__NEXTPRESS_ASSETS__/wc?wc-ajax=update_order_review&product_id=42',
+            $this->invokeTransform(
+                'http://example.com/?wc-ajax=update_order_review&product_id=42',
+                $home,
+                $home
+            )
+        );
+    }
+
+    public function testWpAdminStaticAssetRoutesThroughInternalAssets(): void
+    {
+        $this->assertMapping(
+            'http://__NEXTPRESS_ASSETS__/wp-internal-assets/wp-admin/load-styles.php?ver=6.4',
+            'http://example.com/wp-admin/load-styles.php?ver=6.4',
+            'http://example.com/wp/wp-admin/load-styles.php?ver=6.4'
+        );
+    }
+
+    public function testWpIncludesAssetRoutesThroughInternalAssets(): void
+    {
+        $this->assertMapping(
+            'http://__NEXTPRESS_ASSETS__/wp-internal-assets/wp-includes/js/jquery.js',
+            'http://example.com/wp-includes/js/jquery.js',
+            'http://example.com/wp/wp-includes/js/jquery.js'
+        );
+    }
+
+    public function testWpContentAssetRoutesThroughWpAssets(): void
+    {
+        // wp-content lives below home_url on both root and subdir installs.
+        $this->assertMapping(
+            'http://__NEXTPRESS_ASSETS__/wp-assets/wp-content/plugins/foo/script.js',
+            'http://example.com/wp-content/plugins/foo/script.js',
+            'http://example.com/wp/wp-content/plugins/foo/script.js'
+        );
+    }
+
+    public function testWpJsonRestApiRoutesThroughWpJson(): void
+    {
+        $this->assertMapping(
+            'http://__NEXTPRESS_ASSETS__/wp-json/wc/store/v1/cart',
+            'http://example.com/wp-json/wc/store/v1/cart',
+            'http://example.com/wp/wp-json/wc/store/v1/cart'
+        );
+    }
+
+    public function testPageUrlOnHomeUrlUsesProxyPlaceholder(): void
+    {
+        // home_url-side pages (the public-facing URLs) get the
+        // __NEXTPRESS_PROXY__ placeholder.
+        $home = 'http://example.com';
+        $this->assertSame(
+            'http://__NEXTPRESS_PROXY__/checkout/',
+            $this->invokeTransform('http://example.com/checkout/', $home, $home)
+        );
+        $this->assertSame(
+            'http://__NEXTPRESS_PROXY__/my-account/orders/',
+            $this->invokeTransform('http://example.com/my-account/orders/', $home, $home)
+        );
+    }
+
+    public function testHeadlessSetupWithDifferentFrontendAndBackendHosts(): void
+    {
+        // Realistic headless config: home_url is the frontend (Next.js),
+        // site_url is the WP backend. Both URLs (with their respective
+        // hosts) should map correctly.
+        $home = 'http://frontend.local';
+        $site = 'http://backend.local/wp';
+
+        $this->assertSame(
+            'http://__NEXTPRESS_PROXY__/checkout/',
+            $this->invokeTransform('http://frontend.local/checkout/', $home, $site)
+        );
+
+        $this->assertSame(
+            'http://__NEXTPRESS_ASSETS__/wp',
+            $this->invokeTransform('http://backend.local/wp/wp-admin/admin-ajax.php', $home, $site)
+        );
+
+        $this->assertSame(
+            'http://__NEXTPRESS_ASSETS__/wp-internal-assets/wp-includes/js/jquery.js',
+            $this->invokeTransform('http://backend.local/wp/wp-includes/js/jquery.js', $home, $site)
+        );
+    }
+
+    public function testExternalUrlIsUnchanged(): void
+    {
+        // URLs on neither home_url nor site_url should pass through.
+        $this->assertSame(
+            'https://api.stripe.com/v1/payment_methods',
+            $this->invokeTransform(
+                'https://api.stripe.com/v1/payment_methods',
+                'http://example.com',
+                'http://example.com'
+            )
+        );
+        $this->assertSame(
+            'https://fonts.googleapis.com/css2?family=Inter',
+            $this->invokeTransform(
+                'https://fonts.googleapis.com/css2?family=Inter',
+                'http://example.com',
+                'http://example.com'
+            )
+        );
+    }
+
+    public function testRelativeUrlIsUnchanged(): void
+    {
+        // Strings without a host (relative URLs, raw values) pass through
+        // unchanged; transformation is opt-in via absolute URL host match.
+        $this->assertSame(
+            '/?wc-ajax=%endpoint%',
+            $this->invokeTransform('/?wc-ajax=%endpoint%', 'http://example.com', 'http://example.com')
+        );
+        $this->assertSame(
+            'just a string, not a url',
+            $this->invokeTransform('just a string, not a url', 'http://example.com', 'http://example.com')
+        );
+    }
+
+    public function testHttpsScheme(): void
+    {
+        $this->assertSame(
+            'https://__NEXTPRESS_ASSETS__/wp',
+            $this->invokeTransform(
+                'https://example.com/wp/wp-admin/admin-ajax.php',
+                'https://example.com',
+                'https://example.com/wp'
+            )
+        );
+        $this->assertSame(
+            'https://__NEXTPRESS_PROXY__/cart/',
+            $this->invokeTransform('https://example.com/cart/', 'https://example.com', 'https://example.com')
+        );
+    }
+
+    public function testArrayValuesAreRecursivelyTransformed(): void
+    {
+        $input = [
+            'ajax_url' => 'http://example.com/wp/wp-admin/admin-ajax.php',
+            'cart_url' => 'http://example.com/cart/',
+            'nested'   => [
+                'rest' => 'http://example.com/wp/wp-json/wc/store/v1/cart',
+            ],
+        ];
+
+        $expected = [
+            'ajax_url' => 'http://__NEXTPRESS_ASSETS__/wp',
+            'cart_url' => 'http://__NEXTPRESS_PROXY__/cart/',
+            'nested'   => [
+                'rest' => 'http://__NEXTPRESS_ASSETS__/wp-json/wc/store/v1/cart',
+            ],
+        ];
+
+        $this->assertSame(
+            $expected,
+            $this->invokeTransform($input, 'http://example.com', 'http://example.com/wp')
+        );
+    }
+
+    public function testNonStringNonArrayValuesPassThrough(): void
+    {
+        $this->assertSame(42, $this->invokeTransform(42, 'http://example.com', 'http://example.com'));
+        $this->assertSame(true, $this->invokeTransform(true, 'http://example.com', 'http://example.com'));
+        $this->assertSame(null, $this->invokeTransform(null, 'http://example.com', 'http://example.com'));
+    }
+}


### PR DESCRIPTION
## Summary

- PHP `Assets::transform_stripe_params_urls` strips any `site_url` subdirectory from the URL path before matching, then maps each detected WP URL to the proxy-route alias it belongs to (`/wp`, `/wc`, `/wp-internal-assets/…`, `/wp-assets/…`, `/wp-json/…`). Replaces the prior catch-all `__NEXTPRESS_ASSETS__/<original-path>` placeholder that produced URLs like `/atx/<instance>/wp/wp-admin/admin-ajax.php` which match no `proxyByWCR` matcher and fall through to the headless app (500). Behavior is now identical for root and subdirectory WP installs.
- TS `replaceProxyPlaceholders` drops the pathname concatenation in the frontend origin — previously `frontendOrigin = ${wcr_frontend_url}/${pathname}` leaked the current page path (and a stray double-slash) into every `__NEXTPRESS_PROXY__` expansion.
- Unblocks WC Stripe UPE Classic in headless setups: SetupIntent creation (admin-ajax), payment-intent updates, and other localized AJAX endpoints now reach the WP backend through the body-forwarding `/wp` and `/wc` proxy short aliases.

## Test plan

- [ ] `npm run test -- src/compatibility/woocommerce.spec.ts` in `packages/js` — 16 new specs cover `__NEXTPRESS_PROXY__` and `__NEXTPRESS_ASSETS__` expansion, escaped/unescaped slash forms, multiple occurrences, and the pathname-injection regression.
- [ ] `composer run test` in `packages/wordpress` — `AssetsStripeUrlTransformTest` covers each URL → placeholder mapping for root + `/wp` subdirectory installs, headless setups with split frontend/backend hosts, query preservation, external/relative URL pass-through, recursive array transforms, and https.
- [ ] Manual: with `enable_stripe_url_transforms` on, render a page hosting WC Stripe UPE Classic. Inspect `window.wc_stripe_upe_params.wp_ajax_url` and `ajax_url` — should expand client-side to `/atx/<instance>/wp` and `/atx/<instance>/wc?…` respectively (no `/wp/wp-admin/admin-ajax.php` suffix, no double-slash). Submit add-payment-method form; SetupIntent AJAX should hit the WP backend and return JSON.