### PR TITLE
feat: export CustomParser + ElementProps types from package root

### DIFF
--- a/.changeset/export-parser-types.md
+++ b/.changeset/export-parser-types.md
@@ -1,0 +1,5 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+Export `CustomParser` and `ElementProps` types from the package root. Consumers writing a `Content` `customParser` can now `import type { CustomParser, ElementProps } from '@axistaylor/nextpress'` instead of mirroring the type signature locally. Types are sourced from a new dedicated `parsers/types` module so the parsing utility (`utils/parseHtml`) no longer owns both runtime helpers and public types.

--- a/packages/js/src/Content/Content.tsx
+++ b/packages/js/src/Content/Content.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from 'react';
 import clsx from 'clsx';
 import { getWPInstance } from '@/config/getWPInstance';
-import { parseHtml, CustomParser } from '@/utils/parseHtml';
+import { parseHtml } from '@/utils/parseHtml';
+import type { CustomParser } from '@/parsers/types';
 import { createUrlRewritingParser } from '@/parsers/urlRewritingParser';
 
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -9,3 +9,4 @@ export * from '@/WPFooter';
 export * from '@/ImportMap';
 export { createUrlRewritingParser, type UrlRewritingParserOptions } from '@/parsers/urlRewritingParser';
 export { nextImageParser } from '@/parsers/nextImageParser';
+export type { CustomParser, ElementProps } from '@/parsers/types';

--- a/packages/js/src/parsers/nextImageParser.tsx
+++ b/packages/js/src/parsers/nextImageParser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import type { DOMNode } from 'html-react-parser';
-import type { CustomParser, ElementProps } from '@/utils/parseHtml';
+import type { CustomParser, ElementProps } from '@/parsers/types';
 
 /**
  * Optional Content parser that converts WordPress <img> tags to Next.js

--- a/packages/js/src/parsers/types.ts
+++ b/packages/js/src/parsers/types.ts
@@ -1,0 +1,16 @@
+import type { DOMNode, attributesToProps } from 'html-react-parser';
+
+/**
+ * React props produced by `html-react-parser`'s `attributesToProps`
+ * for the current node. Used by `Content` customParsers to read the
+ * resolved props (data attributes, class names, etc.) without having
+ * to walk the raw `attribs` themselves.
+ */
+export type ElementProps = ReturnType<typeof attributesToProps>;
+
+/**
+ * Signature for a `Content` custom parser. Return a JSX element to
+ * replace the matched node, or `undefined` to let the next parser in
+ * the chain (or the default renderer) handle it.
+ */
+export type CustomParser = (node: DOMNode, props: ElementProps, children?: DOMNode[] | DOMNode) => JSX.Element | undefined;

--- a/packages/js/src/parsers/urlRewritingParser.tsx
+++ b/packages/js/src/parsers/urlRewritingParser.tsx
@@ -4,7 +4,7 @@ import {
   domToReact,
   Element,
 } from 'html-react-parser';
-import type { ElementProps, CustomParser } from '@/utils/parseHtml';
+import type { ElementProps, CustomParser } from '@/parsers/types';
 
 export interface UrlRewritingParserOptions {
   wpHomeUrl?: string;
@@ -64,4 +64,3 @@ export function createUrlRewritingParser({
   };
 }
 
-export { ElementProps, CustomParser };

--- a/packages/js/src/utils/parseHtml.tsx
+++ b/packages/js/src/utils/parseHtml.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
 import parse, {
-  DOMNode,
   domToReact,
   HTMLReactParserOptions,
   Element,
   attributesToProps,
 } from 'html-react-parser';
 
-/**
- * Type for HTML element props returned by attributesToProps
- */
-export type ElementProps = ReturnType<typeof attributesToProps>;
-
-/**
- * Type for custom parser functions
- */
-export type CustomParser = (node: DOMNode, props: ElementProps, children?: DOMNode[]|DOMNode) => JSX.Element | undefined;
+import type { CustomParser } from '@/parsers/types';
 
 export function parseHtml(
   html: string,


### PR DESCRIPTION
## Summary
- Adds `CustomParser` and `ElementProps` to the public API surface so consumers writing a `Content` `customParser` can `import type { CustomParser, ElementProps } from '@axistaylor/nextpress'` instead of redefining the signature locally.
- Sourced from a new dedicated `packages/js/src/parsers/types.ts` so `utils/parseHtml` no longer doubles as both runtime helpers and public types.
- Internal call sites (`parseHtml`, `Content`, `urlRewritingParser`, `nextImageParser`) updated to consume the types from the new location.

## Test plan
- [x] \`npm run typecheck\` passes in \`packages/js\`
- [x] \`npm run test\` passes in \`packages/js\`