### PR TITLE
fix(AssetUpdater): bypassDomains for external-origin assets

### DIFF
--- a/.changeset/asset-updater-bypass-domains.md
+++ b/.changeset/asset-updater-bypass-domains.md
@@ -1,0 +1,9 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+`AssetUpdater`: add a `bypassDomains` prop so scripts and stylesheets from listed origins (payment gateways, web fonts, analytics) load from their original URL instead of being routed through the instance asset proxy — where they 404 on client-side navigation (e.g. `https://js.stripe.com/v3/` → `/atx/<instance>/wp-assets/v3/`).
+
+Domains are matched by hostname (scheme- and port-agnostic), with root domains covering subdomains — `stripe.com` covers `js.stripe.com`. This mirrors the server-side external-origin check, so the initial SSR markup and navigation-time markup (and the external-script dedupe key) stay in sync.
+
+Also removes leftover `[AssetUpdater]` debug console logs.

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -30,14 +30,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      # Node 24 bundles npm 11, whose `npm ci` stalls on this dependency tree;
-      # pin to npm 10 to match the Node 20/22 jobs.
-      - name: Pin npm 10
-        if: matrix.node-version == 24
-        run: npm install -g npm@10
-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build package
         run: npm run build:js

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci --ignore-scripts
 
       - name: Build package
         run: npm run build:js

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -30,6 +30,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      # Node 24 bundles npm 11, whose `npm ci` stalls on this dependency tree;
+      # pin to npm 10 to match the Node 20/22 jobs.
+      - name: Pin npm 10
+        if: matrix.node-version == 24
+        run: npm install -g npm@10
+
       - name: Install dependencies
         run: npm ci
 

--- a/docs/api/asset-updater.md
+++ b/docs/api/asset-updater.md
@@ -26,6 +26,7 @@ import {
 export interface AssetUpdaterProps {
   fetchAssets: (uri: string) => Promise<AssetData>;
   instance?: string;
+  bypassDomains?: string[];
 }
 
 export function AssetUpdater(props: AssetUpdaterProps) {
@@ -34,6 +35,7 @@ export function AssetUpdater(props: AssetUpdaterProps) {
     <BaseAssetUpdater
       fetchAssets={props.fetchAssets}
       instance={props.instance}
+      bypassDomains={props.bypassDomains}
       pathname={pathname}
     />
   );
@@ -102,6 +104,7 @@ export async function fetchAssets(uri: string): Promise<AssetData> {
 | `pathname` | `string` | Yes | The current pathname being rendered (usually sourced from `headers().get('x-uri')`) |
 | `fetchAssets` | `(uri: string) => Promise<AssetData>` | Yes | Server action that returns fresh stylesheets, scripts, and global styles for a URI |
 | `instance` | `string` | No | WordPress instance slug used for proxy URL rewriting (default: `'default'`) |
+| `bypassDomains` | `string[]` | No | Domains whose scripts/stylesheets load directly from their original URL instead of being proxied — e.g. `['js.stripe.com', 'fonts.googleapis.com']`. Matched by hostname; a root domain covers its subdomains (`stripe.com` covers `js.stripe.com`). Default: `[]` |
 
 ### `AssetData`
 
@@ -130,6 +133,23 @@ On initial mount the effect is skipped (the server already rendered those assets
 3. Clears every DOM node between each marker pair and reinserts fresh elements — stylesheets first, then head scripts, then body scripts — matching the document order the server would have produced.
 4. Inserts scripts **sequentially**, awaiting each one's load (`async=false` for external, event-dispatched completion for inline), so execution order and cross-script global state are preserved.
 5. Fires `DOMContentLoaded`, `load`, and `nextpress:page-change` so WordPress scripts that initialize on those events get a chance to re-run.
+
+## External Origins (`bypassDomains`)
+
+By default every stylesheet/script `src` is rewritten to route through the instance asset proxy (`/atx/<instance>/wp-assets/…`). That's correct for WordPress-served assets, but breaks third-party assets that can't be served through the proxy — payment gateways, web fonts, analytics, and the like (e.g. `https://js.stripe.com/v3/` would become `/atx/<instance>/wp-assets/v3/` and 404).
+
+Pass `bypassDomains` to keep those assets on their original URL:
+
+```tsx
+<AssetUpdater
+  fetchAssets={fetchAssets}
+  bypassDomains={['js.stripe.com', 'fonts.googleapis.com', 'fonts.gstatic.com']}
+/>
+```
+
+Matching is by **hostname** (scheme- and port-agnostic), and a root domain covers its subdomains — `stripe.com` matches both `stripe.com` and `js.stripe.com`.
+
+Keep this list aligned with the external origins your server-side asset rendering already emits directly: the server marks non-WordPress origins as external and renders their raw URLs, and `bypassDomains` is how the client reproduces that decision on navigation. When they agree, the initial SSR markup and the navigation-time markup match — including the external-script dedupe key — so third-party scripts aren't re-run.
 
 ## Inline Script Synchronization
 

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { EnqueuedScript, EnqueuedStylesheet, GlobalStylesType, ScriptLoadingGroupEnum, ScriptTypeEnum } from '@/types';
 import { WPImport } from '@/ImportMap';
 import { scopeInlineStyles } from '@/utils/scopeStyles';
-import { transformAssetUrl } from '@/utils/url';
+import { transformAssetUrl, isBypassedHost } from '@/utils/url';
 import { firePageEvents } from '@/hooks/usePageEvents';
 import { joinScriptContent } from '@/utils/content';
 import { replaceProxyPlaceholders, processWcSettings } from '@/compatibility/woocommerce';
@@ -29,6 +29,15 @@ export interface AssetData {
  */
 const loadedExternalSrcs = new Set<string>();
 
+/**
+ * Resolves an asset src to load: assets whose host is (or is a subdomain of)
+ * a bypassed domain keep their original external URL; everything else is
+ * routed through the instance asset proxy.
+ */
+function resolveAssetSrc(src: string, instance: string, bypassDomains: string[]): string {
+  return isBypassedHost(src, bypassDomains) ? src : transformAssetUrl(src, instance);
+}
+
 
 export interface AssetUpdaterProps {
   /**
@@ -46,6 +55,13 @@ export interface AssetUpdaterProps {
    * require server-side credentials.
    */
   fetchAssets: (uri: string) => Promise<AssetData>;
+  /**
+   * Domains whose scripts/stylesheets should load directly from their
+   * original URL instead of being proxied through the instance — e.g.
+   * `['js.stripe.com', 'fonts.googleapis.com']`. Matched by hostname, with
+   * root domains covering subdomains (`stripe.com` covers `js.stripe.com`).
+   */
+  bypassDomains?: string[];
 }
 
 /**
@@ -141,7 +157,7 @@ function createScriptElement(
 /**
  * Replaces the stylesheet list between the nextpress-stylesheets-start/end markers.
  */
-function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string): void {
+function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string, bypassDomains: string[]): void {
   const range = clearBetweenMarkers(
     'nextpress-stylesheets-start',
     'nextpress-stylesheets-end',
@@ -166,7 +182,7 @@ function updateStylesheets(stylesheets: EnqueuedStylesheet[], instance: string):
 
     if (stylesheet.src) {
       parent.insertBefore(
-        createLinkElement(handle, transformAssetUrl(stylesheet.src, instance)),
+        createLinkElement(handle, resolveAssetSrc(stylesheet.src, instance, bypassDomains)),
         endMarker,
       );
     }
@@ -193,6 +209,7 @@ async function updateScripts(
   endId: string,
   instance: string,
   pathname: string,
+  bypassDomains: string[],
 ): Promise<void> {
   // Seed the dedupe set from scripts currently between the markers
   // before clearing. Server-rendered scripts (initial page load) and
@@ -247,12 +264,9 @@ async function updateScripts(
     onExecuted?: () => void,
   ): Promise<void> => {
     const eventName = `nextpress:inline-executed:${id}`;
-    const instrumented = `${content}\n;console.log('[AssetUpdater] inline executed:', ${JSON.stringify(id)});document.dispatchEvent(new CustomEvent(${JSON.stringify(eventName)}));`;
+    const instrumented = `${content}\n;document.dispatchEvent(new CustomEvent(${JSON.stringify(eventName)}));`;
     const executed = new Promise<void>((resolve) => {
-      document.addEventListener(eventName, () => {
-        console.log('[AssetUpdater] event received:', eventName);
-        resolve();
-      }, { once: true });
+      document.addEventListener(eventName, () => resolve(), { once: true });
     });
     await insert(id, { content: instrumented });
     await executed;
@@ -272,7 +286,7 @@ async function updateScripts(
     // ES modules don't have inline extra/before/after scripts — just load the src.
     if (isModule) {
       if (script.src) {
-        const src = transformAssetUrl(script.src, instance);
+        const src = resolveAssetSrc(script.src, instance, bypassDomains);
         if (!loadedExternalSrcs.has(src)) {
           loadedExternalSrcs.add(src);
           await insert(handle, { src, isModule: true });
@@ -295,16 +309,13 @@ async function updateScripts(
         `${handle}-js-before`,
         beforeScript,
         handle === 'wc-settings'
-          ? () => {
-              console.log('[AssetUpdater] processWcSettings callback fired, wcSettings:', window.wcSettings);
-              processWcSettings(instance);
-            }
+          ? () => processWcSettings(instance)
           : undefined,
       );
     }
 
     if (script.src) {
-      const src = transformAssetUrl(script.src, instance);
+      const src = resolveAssetSrc(script.src, instance, bypassDomains);
       if (!loadedExternalSrcs.has(src)) {
         loadedExternalSrcs.add(src);
         await insert(handle, { src });
@@ -419,6 +430,7 @@ export function AssetUpdater({
   pathname,
   instance = 'default',
   fetchAssets,
+  bypassDomains = [],
 }: AssetUpdaterProps) {
   // Skip only the initial mount — the server already rendered those assets.
   // Every effect run after the first one (including returning to the initial
@@ -441,7 +453,7 @@ export function AssetUpdater({
         const assets = await fetchAssets(pathname);
         if (cancelled) return;
 
-        updateStylesheets(assets.stylesheets, instance);
+        updateStylesheets(assets.stylesheets, instance, bypassDomains);
         updateGlobalStyles(assets.globalStyles, instance, pathname);
         updateImportMap(assets.importMap, instance, pathname);
 
@@ -455,6 +467,7 @@ export function AssetUpdater({
           'nextpress-head-scripts-end',
           instance,
           pathname,
+          bypassDomains,
         );
         if (cancelled) return;
 
@@ -465,6 +478,7 @@ export function AssetUpdater({
           'nextpress-body-scripts-end',
           instance,
           pathname,
+          bypassDomains,
         );
         if (cancelled) return;
 

--- a/packages/js/src/utils/url.ts
+++ b/packages/js/src/utils/url.ts
@@ -16,6 +16,25 @@ function getHost(url: string): string | null {
 }
 
 /**
+ * True when the URL's hostname is, or is a subdomain of, any domain in the
+ * bypass list. Matched scheme- and port-agnostically by hostname, with root
+ * domains covering their subdomains — `stripe.com` matches both `stripe.com`
+ * and `js.stripe.com`.
+ */
+export function isBypassedHost(url: string, bypassDomains: string[]): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(withScheme(url)).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return bypassDomains.some((domain) => {
+    const d = domain.trim().toLowerCase().replace(/^\.+/, '').replace(/\/.*$/, '');
+    return d !== '' && (hostname === d || hostname.endsWith(`.${d}`));
+  });
+}
+
+/**
  * Extracts the path from a URL, removing the protocol and domain.
  */
 export function extractPath(url: string): string {


### PR DESCRIPTION
## Summary

- `AssetUpdater` proxied every stylesheet/script `src` through `/atx/<instance>/wp-assets/…`, which 404s for third-party assets that can't be served via the proxy (payment gateways, web fonts, analytics) — e.g. `https://js.stripe.com/v3/` → `/atx/<instance>/wp-assets/v3/`.
- Adds an opt-in `bypassDomains?: string[]` prop. Assets whose hostname is, or is a subdomain of, a listed domain load directly from their original URL instead of being proxied. Matched by hostname (scheme-/port-agnostic); a root domain covers its subdomains (`stripe.com` covers `js.stripe.com`).
- New `isBypassedHost()` helper in `utils/url.ts`; threaded through `updateStylesheets` and `updateScripts` via a small `resolveAssetSrc` wrapper. Default `[]` keeps existing behavior unchanged.
- Mirrors the server-side external-origin check, so SSR markup and navigation-time markup (and the external-script dedupe key) stay in sync.
- Removes leftover `[AssetUpdater]` debug console logs.
- Docs + changeset (`patch`) included.

## Test plan

- [ ] With `bypassDomains={['js.stripe.com', 'fonts.googleapis.com', 'fonts.gstatic.com']}`, navigate client-side to a page enqueuing those assets; confirm the `<script>`/`<link>` `src` is the raw third-party URL (not `/atx/.../wp-assets/...`) and the asset loads (no 404).
- [ ] Confirm WordPress-served assets still proxy through `/atx/<instance>/wp-assets/…`.
- [ ] Without the prop (default `[]`), behavior is unchanged.
- [ ] No `[AssetUpdater]` logs in the console on navigation.