### PR TITLE
feat(stylesheets): defer non-critical sheets via criticalHandles whitelist

### DIFF
--- a/.changeset/defer-non-critical-stylesheets.md
+++ b/.changeset/defer-non-critical-stylesheets.md
@@ -1,0 +1,20 @@
+---
+"@axistaylor/nextpress": minor
+---
+
+Defer non-critical proxied stylesheets to stop them from render-blocking first paint.
+
+`Stylesheets` (and `WPHead`, which forwards) accept a new optional `criticalHandles?: string[]` prop. Handles in the list keep the current render-blocking `<link rel="stylesheet">` + `preinit` behavior. Anything outside the list is rendered with `media="print"` + `data-np-defer="1"`; an inline swap-script promotes those links to `media="all"` on load (synchronously for cache hits via `link.sheet`). Cascade order is preserved because DOM order — not load order — drives the cascade, and `before`/`after` inline styles are untouched.
+
+Omitting `criticalHandles` keeps every sheet blocking, matching previous behavior. Pass it from a layout to mark theme + critical layout sheets so they keep blocking while everything else defers:
+
+```tsx
+<WPHead
+  scripts={scripts}
+  stylesheets={stylesheets}
+  globalStyles={globalStyles}
+  importMap={importMap}
+  pathname={uri}
+  criticalHandles={['theme', 'wp-block-library']}
+/>
+```

--- a/packages/js/src/Stylesheets/Stylesheets.tsx
+++ b/packages/js/src/Stylesheets/Stylesheets.tsx
@@ -19,15 +19,34 @@ export interface StyleProps {
 
 const Style = 'style' as unknown as FC<StyleProps>;
 
+// Promotes every `data-np-defer` link from a non-matching
+// `media="print"` to `media="all"` once the stylesheet has loaded.
+// Print-media links don't block first paint; promoting them on
+// `load` applies the styles without a second fetch (the browser
+// reuses the print sheet). Cache-hit links arrive with `.sheet`
+// already populated and no `load` event coming, so we promote
+// those synchronously.
+const DEFER_SWAP_SCRIPT = "(function(){function s(l){l.media='all';}document.querySelectorAll('link[data-np-defer]').forEach(function(l){if(l.sheet){s(l);}else{l.addEventListener('load',function(){s(l);},{once:true});}});})();";
+
 export type StylesheetsProps = {
   stylesheets: EnqueuedStylesheet[];
   instance?: string;
   pathname?: string;
+  /**
+   * Handles of stylesheets that should keep blocking first paint.
+   * Anything not in this list ships with `media="print"` and gets
+   * promoted to `media="all"` once the sheet has loaded — so
+   * Lighthouse stops flagging it as render-blocking. Omit the
+   * prop to defer every sheet (matches the previous default
+   * behaviour but is no longer recommended for theme-critical
+   * stylesheets).
+   */
+  criticalHandles?: string[];
 };
 
 export const resolveStylesheetHref = resolveAssetHref;
 
-export function Stylesheets({ stylesheets, instance = 'default', pathname: _pathname = '' }: StylesheetsProps) {
+export function Stylesheets({ stylesheets, instance = 'default', pathname: _pathname = '', criticalHandles }: StylesheetsProps) {
   const { wpHomeUrl } = getWPInstance(instance);
   const otherInstances = Object.entries(getAllWPInstances())
     .reduce((acc, [slug, entry]) => {
@@ -38,18 +57,31 @@ export function Stylesheets({ stylesheets, instance = 'default', pathname: _path
       return acc;
     }, {} as Record<string, string>);
 
+  const criticalSet = criticalHandles ? new Set(criticalHandles) : null;
+  let anyDeferred = false;
+
   return (
     <Fragment>
       <Style id="nextpress-stylesheets-start">{`/* nextpress:stylesheets-start */`}</Style>
       {stylesheets.map((stylesheet) => {
         const { handle, src } = stylesheet;
+        const isCritical = criticalSet ? criticalSet.has(handle as string) : false;
 
         let href = '';
         if (src) {
           href = resolveAssetHref(src, instance, wpHomeUrl, otherInstances);
-          preinit(href, { as: 'style', precedence: handle as string });
+          // preinit is render-blocking, so reserve it for the
+          // critical-path sheets that we're already blocking on.
+          if (isCritical) {
+            preinit(href, { as: 'style', precedence: handle as string });
+          }
         }
-        const Link = 'link' as unknown as FC<JSX.IntrinsicElements['link'] & { precedence: string }>;
+        const Link = 'link' as unknown as FC<
+          JSX.IntrinsicElements['link'] & { precedence: string; 'data-np-defer'?: string }
+        >;
+        if (href && !isCritical) {
+          anyDeferred = true;
+        }
         return (
           <Fragment key={handle}>
             {stylesheet.before && (
@@ -58,7 +90,18 @@ export function Stylesheets({ stylesheets, instance = 'default', pathname: _path
               </Style>
             )}
             {href && (
-              <Link rel="stylesheet" href={href} id={`${handle}-css`} precedence={handle as string} />
+              isCritical ? (
+                <Link rel="stylesheet" href={href} id={`${handle}-css`} precedence={handle as string} />
+              ) : (
+                <Link
+                  rel="stylesheet"
+                  href={href}
+                  id={`${handle}-css`}
+                  precedence={handle as string}
+                  media="print"
+                  data-np-defer="1"
+                />
+              )
             )}
             {stylesheet.after && (
               <Style id={`${handle}-inline-css`} precedence={handle as string} href={`${handle}-after-inline`}>
@@ -69,6 +112,12 @@ export function Stylesheets({ stylesheets, instance = 'default', pathname: _path
         );
       })}
       <Style id="nextpress-stylesheets-end">{`/* nextpress:stylesheets-end */`}</Style>
+      {anyDeferred && (
+        <script
+          id="nextpress-deferred-css-swap"
+          dangerouslySetInnerHTML={{ __html: DEFER_SWAP_SCRIPT }}
+        />
+      )}
     </Fragment>
   );
 }

--- a/packages/js/src/WPHead/WPHead.tsx
+++ b/packages/js/src/WPHead/WPHead.tsx
@@ -12,17 +12,29 @@ export interface WPHeadProps {
   importMap?: WPImport[];
   instance?: string;
   pathname?: string;
+  /**
+   * Handles of stylesheets that should keep blocking first paint
+   * (typically theme + critical layout sheets). Everything else is
+   * deferred — fetched with `media="print"` and promoted on load.
+   * Forwarded to `Stylesheets`.
+   */
+  criticalHandles?: string[];
 }
 
 /**
  * Server component that renders all WordPress head assets: global styles,
  * stylesheets, the script module import map, and header scripts.
  */
-export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance = 'default', pathname = '' }: WPHeadProps) {
+export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance = 'default', pathname = '', criticalHandles }: WPHeadProps) {
   return (
     <>
       {stylesheets && stylesheets.length > 0 && (
-        <Stylesheets stylesheets={stylesheets} instance={instance} pathname={pathname} />
+        <Stylesheets
+          stylesheets={stylesheets}
+          instance={instance}
+          pathname={pathname}
+          criticalHandles={criticalHandles}
+        />
       )}
       {globalStyles && (
         <GlobalStyles globalStyles={globalStyles} instance={instance} pathname={pathname} />

--- a/packages/nextjs-example/app/(wordpress-pages)/layout.tsx
+++ b/packages/nextjs-example/app/(wordpress-pages)/layout.tsx
@@ -23,6 +23,21 @@ export const metadata: Metadata = {
 // Force dynamic rendering to prevent caching of WordPress scripts/styles with stale nonces
 export const dynamic = 'force-dynamic';
 
+// Sheets that must paint above the fold. Anything outside this list
+// ships as `media="print"` and is promoted to `media="all"` once it
+// has loaded — so Lighthouse stops counting them as render-blocking.
+//
+// Adjust to match the active theme: include the theme's main handle
+// (typically `<theme-slug>-style`) plus any layout-critical sheets.
+const CRITICAL_STYLESHEET_HANDLES = [
+  'wp-block-library',
+  'wp-block-library-theme',
+  'global-styles',
+  'classic-theme-styles',
+  // Active theme shipped with backend-4-examples:
+  'custom-block-theme-style',
+];
+
 export default async function WordPressLayout({
   children,
 }: Readonly<PropsWithChildren>) {
@@ -41,6 +56,7 @@ export default async function WordPressLayout({
           globalStyles={globalStyles}
           importMap={importMap}
           pathname={uri}
+          criticalHandles={CRITICAL_STYLESHEET_HANDLES}
         />
       </head>
       <body className={inter.className}>


### PR DESCRIPTION
## Summary
- Adds a `criticalHandles?: string[]` prop to `WPHead` (forwarded to `Stylesheets`) so consumers can pin theme + critical layout sheets to render-blocking while every other proxied sheet defers.
- Non-critical sheets now ship as `<link rel="stylesheet" media="print" data-np-defer="1">`; a single inline swap-script promotes `media` to `'all'` on `load` (synchronously for cache hits via `link.sheet`).
- `preinit` is now reserved for critical handles only; the swap-script is only emitted when something is actually deferred. Cascade DOM order is preserved, and `before`/`after` inline styles are untouched.
- Omitting `criticalHandles` keeps every sheet blocking — no behavior change for existing consumers.

## Test plan
- [ ] Layout passing `criticalHandles={['theme', 'wp-block-library']}` keeps those two `<link>` tags as `media="all"` and defers everything else.
- [ ] First visit: deferred links show `media="print"` in HTML; after the swap-script runs, DevTools shows `media="all"` on each.
- [ ] Cache-hit visit (e.g. via Cloudflare 30d edge cache on proxied assets): swap-script promotes synchronously, no FOUC.
- [ ] Cascade order: theme rules still override `wp-block-library` rules where expected.
- [ ] `before`/`after` inline `<style>` tags still emit in the right position around each external link.
- [ ] Lighthouse on a representative page: "Eliminate render-blocking resources" no longer lists the proxied WP sheets that aren't in `criticalHandles`.
- [ ] e2e suite still passes (style-isolation specs in particular).