### PR TITLE
feat(global-styles): defer font-faces + opt-in deferGlobalStyles knob

### DIFF
--- a/.changeset/defer-fonts-and-globalstyles.md
+++ b/.changeset/defer-fonts-and-globalstyles.md
@@ -1,0 +1,12 @@
+---
+"@axistaylor/nextpress": minor
+---
+
+Defer the theme.json `@font-face` block off the critical path, with a matching opt-in knob for the theme.json `stylesheet` content.
+
+- `GlobalStyles` accepts two new props:
+  - `deferFonts?: boolean` — default `true`. Renders the `@font-face` `<style>` with `media="print" data-np-defer="1"` and emits an inline swap-script that promotes it to `media="all"` once parsed. Text above the fold paints with system fallbacks (per `font-display: swap`) and repaints with the web font as soon as it's downloaded — same final result, but Lighthouse no longer counts font-face declarations against "Eliminate render-blocking resources". Set to `false` when above-the-fold text uses glyphs that don't exist in any fallback (icon fonts, custom symbol fonts).
+  - `deferGlobalStyles?: boolean` — default `false`. Same defer pattern for the theme.json `stylesheet` block (CSS custom property bindings + base block-supports rules). Off by default because these usually carry layout-critical tokens; opt in only when you can absorb a token-flash on first paint.
+- `WPHead` forwards both new props.
+- The `Stylesheets` swap-script selector now matches both `link[data-np-defer]` and `style[data-np-defer]`, so the same inline script handles deferred `<link>` sheets and deferred inline `<style>` blocks. `GlobalStyles` also ships its own copy of the script for setups where `Stylesheets` is unused or has no deferred handles, so the deferral works in both arrangements.
+- Documented `criticalHandles` (shipped in v1.3.0 but previously undocumented) in `docs/api/stylesheets.md` with the trade-off profile, plus reference-linked it from `docs/api/wp-head.md`.

--- a/docs/api/global-styles.md
+++ b/docs/api/global-styles.md
@@ -36,6 +36,18 @@ export default async function WordPressLayout({ children }) {
 | `globalStyles` | `GlobalStylesType \| null` | Yes | Payload from the `globalStyles` GraphQL query |
 | `instance` | `string` | No | WordPress instance slug (default: `'default'`) |
 | `pathname` | `string` | No | Current page pathname; used when resolving proxy URL placeholders in font-face rules |
+| `deferFonts` | `boolean` | No | Defer the `@font-face` block off the critical path. Default `true`. See [Deferring fonts](#deferring-fonts). |
+| `deferGlobalStyles` | `boolean` | No | Defer the theme.json `stylesheet` content. Default `false` — opt in only when you can absorb a token-flash on first paint. |
+
+## Deferring fonts
+
+By default `deferFonts: true` renders the `@font-face` `<style>` tag with `media="print" data-np-defer="1"` and emits a short inline script that swaps `media` to `"all"` once the rules are parsed. Lighthouse stops counting font-face declarations against "Eliminate render-blocking resources" without any visible regression — text above the fold paints with the system fallback (per `font-display: swap`) and re-paints with the web font as soon as it's downloaded, same as without the defer.
+
+Set `deferFonts={false}` if text above the fold uses glyphs that don't exist in any system fallback (icon fonts, custom symbol fonts), where rendering with the fallback would show `□` boxes instead of the intended character.
+
+## Deferring globalStyles
+
+`deferGlobalStyles: false` (the default) keeps the theme.json `stylesheet` content (CSS custom property bindings + base block-supports rules) on the critical path. Set to `true` only when you can absorb a token-flash on first paint — for example, when the application chrome paints its own values via your design system before any WordPress block is visible.
 
 ## GraphQL Query
 

--- a/docs/api/stylesheets.md
+++ b/docs/api/stylesheets.md
@@ -35,6 +35,44 @@ export default async function WordPressLayout({ children }) {
 | `stylesheets` | `EnqueuedStylesheet[]` | Yes | Array of WordPress stylesheets to render |
 | `instance` | `string` | No | WordPress instance slug (default: `'default'`) |
 | `pathname` | `string` | No | Current page pathname for scoping |
+| `criticalHandles` | `string[]` | No | Handles to keep render-blocking (see [Critical handles](#critical-handles) below). Omit to keep all sheets blocking (legacy behaviour). |
+
+## Critical handles
+
+By default — when `criticalHandles` is omitted — every proxied stylesheet renders as a normal render-blocking `<link rel="stylesheet">`, which is what Lighthouse flags as "Eliminate render-blocking resources".
+
+Pass `criticalHandles` to whitelist the small set of stylesheets that genuinely need to paint above the fold (typically your theme stylesheet + `wp-block-library` + `wp-block-library-theme` + `global-styles`). Anything **not** in the whitelist gets the deferred treatment:
+
+1. `<link rel="stylesheet" href="…" media="print" data-np-defer="1" precedence="…">` — the browser fetches it at a non-render-blocking priority.
+2. An inline swap-script at the end of the stylesheets fragment promotes `media` to `"all"` on the `load` event (synchronously for cache hits via `link.sheet`).
+
+```tsx
+<Stylesheets
+  stylesheets={stylesheets}
+  criticalHandles={[
+    'wp-block-library',
+    'wp-block-library-theme',
+    'global-styles',
+    'classic-theme-styles',
+    'my-theme-style',          // your theme's main handle
+  ]}
+/>
+```
+
+### Trade-offs
+
+**Cascade order is preserved.** CSS cascade is decided by the DOM position of `<link>` / `<style>` elements, not load order. We keep DOM positions (via React 19's `precedence` prop), so once every deferred sheet has loaded + swapped to `media="all"`, the browser re-evaluates the cascade with the same precedence chain.
+
+**Transient FOUC on first visit.** Between First Contentful Paint and the deferred sheets finishing their `load` event (~50–500ms), only your critical sheets + the inline `before` / `after` chunks (which WordPress enqueues alongside each sheet) apply. Anything that exists **only** in a deferred sheet shows a flash of unstyled content. The `before` / `after` inlines usually cover CSS-custom-property bindings + block-supports CSS for above-the-fold elements, which is why the practical FOUC is small — but it's not zero.
+
+**Subsequent visits are FOUC-free.** Cache-hit deferred links have `link.sheet` populated synchronously when the swap-script runs, so the promotion happens before paint. Pairs nicely with an edge cache (Cloudflare, etc.) on proxied WP assets.
+
+### When to skip it
+
+Omitting `criticalHandles` keeps every sheet render-blocking — the previous default. Drop the prop if:
+- Your CSS budget is small enough that render-blocking isn't measurably hurting LCP.
+- You can't tolerate any transient FOUC (e.g. brand-critical content where the wrong fallback paint is worse than slower TTFB).
+- A specific sheet ships layout rules that aren't in any `before` / `after` inline counterpart — and you can't audit which one. In that case, easier to keep everything blocking than to debug FOUC.
 
 ## Placement
 

--- a/docs/api/wp-head.md
+++ b/docs/api/wp-head.md
@@ -47,10 +47,39 @@ export default async function WordPressLayout({ children }) {
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
 | `scripts` | `EnqueuedScript[]` | Yes | Array of WordPress scripts to render |
-| `globalStyles` | `GlobalStylesType \| null` | No | WordPress global styles (theme.json stylesheet, custom CSS, font faces) |
+| `stylesheets` | `EnqueuedStylesheet[]` | No | Per-page WordPress stylesheets. Forwarded to [`Stylesheets`](./stylesheets.md). |
+| `globalStyles` | `GlobalStylesType \| null` | No | WordPress global styles (theme.json stylesheet, custom CSS, font faces). Forwarded to [`GlobalStyles`](./global-styles.md). |
 | `importMap` | `WPImport[]` | No | Import map entries for script modules (`@wordpress/interactivity`, etc.) |
 | `instance` | `string` | No | WordPress instance slug (default: `'default'`) |
 | `pathname` | `string` | No | Current page pathname |
+| `criticalHandles` | `string[]` | No | Stylesheet handles to keep render-blocking; everything else is deferred via `media="print"` + swap-on-load. Forwarded to [`Stylesheets`](./stylesheets.md#critical-handles). Omit to keep all sheets blocking. |
+| `deferFonts` | `boolean` | No | Defer the theme.json `@font-face` block off the critical path. Default `true`. Forwarded to [`GlobalStyles`](./global-styles.md#deferring-fonts). |
+| `deferGlobalStyles` | `boolean` | No | Defer the theme.json `stylesheet` content. Default `false`. Forwarded to [`GlobalStyles`](./global-styles.md#deferring-globalstyles). |
+
+## Render-blocking budget
+
+The three defer-related props above are all opt-in tuning knobs against Lighthouse's "Eliminate render-blocking resources" audit. Reasonable starting configuration for a typical content site:
+
+```tsx
+<WPHead
+  scripts={scripts}
+  stylesheets={stylesheets}
+  globalStyles={globalStyles}
+  importMap={importMap}
+  pathname={uri}
+  criticalHandles={[
+    'wp-block-library',
+    'wp-block-library-theme',
+    'global-styles',
+    'classic-theme-styles',
+    'my-theme-style',
+  ]}
+  // deferFonts: true (default)
+  // deferGlobalStyles: false (default)
+/>
+```
+
+That keeps the WP core block library + your theme stylesheet on the critical path while deferring every WC-Blocks / plugin-specific stylesheet, and lifts `@font-face` declarations out of the way too. See the linked component docs for trade-offs and the FOUC profile.
 
 ## What It Renders
 

--- a/packages/js/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/js/src/GlobalStyles/GlobalStyles.tsx
@@ -7,17 +7,61 @@ export interface GlobalStylesProps {
   globalStyles: GlobalStylesType;
   instance?: string;
   pathname?: string;
+  /**
+   * Defer the `@font-face` block — render it with `media="print"`
+   * and `data-np-defer` so the same swap script `Stylesheets`
+   * emits promotes it to `media="all"` on the next tick. Stops
+   * font face declarations from blocking first paint when the
+   * page hasn't actually used any of those fonts above the fold.
+   * Defaults to `true`; set to `false` to keep font faces active
+   * on initial paint.
+   */
+  deferFonts?: boolean;
+  /**
+   * Defer the theme.json `stylesheet` block (CSS custom property
+   * bindings + base block-supports rules). Defaults to `false`
+   * because these usually carry layout-critical tokens — opt in
+   * only when you can absorb a token-flash on first paint, or when
+   * the app shell repaints the relevant area anyway. Apply alongside
+   * `deferFonts` to lift both off the critical path.
+   */
+  deferGlobalStyles?: boolean;
 }
+
+// Type loophole: `style[media]` is a valid HTML attribute but
+// JSX.IntrinsicElements['style'] (per React 19's typings) misses
+// the standard MediaQuery type. Cast to a type that accepts it.
+type StyleEl = React.FC<
+  JSX.IntrinsicElements['style'] & { media?: string; 'data-np-defer'?: string }
+>;
+const Style = 'style' as unknown as StyleEl;
+
+// Same swap script `Stylesheets` ships — duplicated here so the
+// font-face deferral works in setups that use `GlobalStyles`
+// standalone (or with all stylesheets marked critical). Idempotent
+// against multiple emissions: every run promotes any unpromoted
+// `data-np-defer` element to `media="all"`, and a subsequent run
+// finds nothing to do.
+const FONT_DEFER_SWAP_SCRIPT = "(function(){function s(l){l.media='all';}document.querySelectorAll('link[data-np-defer],style[data-np-defer]').forEach(function(l){if(l.sheet){s(l);}else{l.addEventListener('load',function(){s(l);},{once:true});}});})();";
 
 /**
  * Renders global WordPress styles from theme.json, custom CSS, and font faces.
  * These are styles that WordPress outputs on every page but are not included
  * in per-page enqueued assets.
+ *
+ * Font faces are deferred by default (see `deferFonts`) since they
+ * don't usually affect first paint — text renders with system
+ * fallbacks until the web font finishes downloading. Theme.json
+ * `stylesheet` content + `customCss` are kept on the critical path
+ * because they carry CSS custom property bindings and layout rules
+ * that DO affect first paint.
  */
 export function GlobalStyles({
   globalStyles,
   instance = 'default',
   pathname = '',
+  deferFonts = true,
+  deferGlobalStyles = false,
 }: GlobalStylesProps) {
   const { stylesheet, customCss, renderedFontFaces } = globalStyles;
 
@@ -55,19 +99,21 @@ export function GlobalStyles({
         dangerouslySetInnerHTML={{ __html: '@layer wp-theme;' }}
       />
       {fontFaceCss && (
-        <style
+        <Style
           id="nextpress-font-faces"
           className="wp-fonts-local"
           data-nextpress="global"
+          {...(deferFonts ? { media: 'print', 'data-np-defer': '1' } : {})}
           dangerouslySetInnerHTML={{ __html: fontFaceCss }}
         />
       )}
       {stylesheet && (
-        <style
+        <Style
           id="nextpress-global-styles"
           data-nextpress="global"
+          {...(deferGlobalStyles ? { media: 'print', 'data-np-defer': '1' } : {})}
           dangerouslySetInnerHTML={{ __html: scopeInlineStyles(stylesheet, { layer: 'wp-theme' }) }}
-          precedence="high"
+          {...({ precedence: 'high' } as { precedence: string })}
         />
       )}
       {customCss && (
@@ -75,6 +121,12 @@ export function GlobalStyles({
           id="nextpress-custom-css"
           data-nextpress="global"
           dangerouslySetInnerHTML={{ __html: scopeInlineStyles(customCss, { layer: 'wp-theme' }) }}
+        />
+      )}
+      {((deferFonts && fontFaceCss) || (deferGlobalStyles && stylesheet)) && (
+        <script
+          id="nextpress-global-defer-swap"
+          dangerouslySetInnerHTML={{ __html: FONT_DEFER_SWAP_SCRIPT }}
         />
       )}
     </Fragment>

--- a/packages/js/src/Stylesheets/Stylesheets.tsx
+++ b/packages/js/src/Stylesheets/Stylesheets.tsx
@@ -19,14 +19,20 @@ export interface StyleProps {
 
 const Style = 'style' as unknown as FC<StyleProps>;
 
-// Promotes every `data-np-defer` link from a non-matching
-// `media="print"` to `media="all"` once the stylesheet has loaded.
-// Print-media links don't block first paint; promoting them on
-// `load` applies the styles without a second fetch (the browser
-// reuses the print sheet). Cache-hit links arrive with `.sheet`
-// already populated and no `load` event coming, so we promote
-// those synchronously.
-const DEFER_SWAP_SCRIPT = "(function(){function s(l){l.media='all';}document.querySelectorAll('link[data-np-defer]').forEach(function(l){if(l.sheet){s(l);}else{l.addEventListener('load',function(){s(l);},{once:true});}});})();";
+// Promotes every `data-np-defer` element from `media="print"` to
+// `media="all"` once its stylesheet has loaded.
+//
+// Two element types ride through the same swap:
+//   * `<link rel="stylesheet" media="print">` — print-media stops
+//     the request from blocking first paint. Promoting on `load`
+//     reuses the print sheet (no second fetch). Cache hits arrive
+//     with `.sheet` populated and no `load` event coming, so we
+//     promote those synchronously.
+//   * `<style media="print">` — inline rules (font faces are the
+//     primary case). `.sheet` is populated synchronously on parse,
+//     so we just check it and promote — no load event ever fires
+//     for an inline `<style>`.
+const DEFER_SWAP_SCRIPT = "(function(){function s(l){l.media='all';}document.querySelectorAll('link[data-np-defer],style[data-np-defer]').forEach(function(l){if(l.sheet){s(l);}else{l.addEventListener('load',function(){s(l);},{once:true});}});})();";
 
 export type StylesheetsProps = {
   stylesheets: EnqueuedStylesheet[];

--- a/packages/js/src/WPHead/WPHead.tsx
+++ b/packages/js/src/WPHead/WPHead.tsx
@@ -19,13 +19,28 @@ export interface WPHeadProps {
    * Forwarded to `Stylesheets`.
    */
   criticalHandles?: string[];
+  /**
+   * Defer theme.json `@font-face` declarations so they don't block
+   * first paint. Pass `false` to keep fonts on the critical path
+   * (e.g. when text above the fold relies on glyphs that don't
+   * exist in any system fallback). Forwarded to `GlobalStyles`,
+   * default `true`.
+   */
+  deferFonts?: boolean;
+  /**
+   * Defer theme.json `stylesheet` content (custom-property bindings
+   * + base block-supports rules). Default `false` — these usually
+   * carry layout-critical tokens, so deferring causes a token
+   * flash on first paint. Forwarded to `GlobalStyles`.
+   */
+  deferGlobalStyles?: boolean;
 }
 
 /**
  * Server component that renders all WordPress head assets: global styles,
  * stylesheets, the script module import map, and header scripts.
  */
-export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance = 'default', pathname = '', criticalHandles }: WPHeadProps) {
+export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance = 'default', pathname = '', criticalHandles, deferFonts, deferGlobalStyles }: WPHeadProps) {
   return (
     <>
       {stylesheets && stylesheets.length > 0 && (
@@ -37,7 +52,13 @@ export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance
         />
       )}
       {globalStyles && (
-        <GlobalStyles globalStyles={globalStyles} instance={instance} pathname={pathname} />
+        <GlobalStyles
+          globalStyles={globalStyles}
+          instance={instance}
+          pathname={pathname}
+          deferFonts={deferFonts}
+          deferGlobalStyles={deferGlobalStyles}
+        />
       )}
       {importMap && importMap.length > 0 && (
         <ImportMap imports={importMap} instance={instance} pathname={pathname} />


### PR DESCRIPTION
## Summary

- `GlobalStyles` now defers the theme.json `@font-face` block off the critical path by default (`deferFonts: true`) — emits the `<style>` with `media="print" data-np-defer="1"` plus an inline swap-script that promotes it to `media="all"` on load. Text above the fold paints with system fallbacks (per `font-display: swap`) and repaints with the web font as soon as it's downloaded, but Lighthouse stops counting font-face declarations against "Eliminate render-blocking resources".
- Adds `deferGlobalStyles?: boolean` (default `false`) — same defer pattern for the theme.json `stylesheet` content. Off by default because that block usually carries layout-critical tokens; opt in only when you can absorb a token-flash on first paint.
- `Stylesheets`' swap-script selector now matches both `link[data-np-defer]` and `style[data-np-defer]`, so one inline script handles deferred `<link>` sheets and deferred inline `<style>` blocks. `GlobalStyles` also ships its own copy of the script so the defer works whether or not `Stylesheets` is rendered.
- `WPHead` forwards both new props.
- Documents `criticalHandles` (shipped in v1.3.0 but previously undocumented) in `docs/api/stylesheets.md` with the full trade-off profile, plus cross-references it from `docs/api/wp-head.md` and `docs/api/global-styles.md`.

## Test plan

- [ ] Build the package — `npm run build` inside `packages/js`
- [ ] Verify `<style id="nextpress-font-faces">` renders with `media="print" data-np-defer="1"` by default
- [ ] Verify the swap-script appears once even when both `Stylesheets` and `GlobalStyles` defer content
- [ ] Verify passing `deferFonts={false}` keeps the font-face block render-blocking
- [ ] Verify `deferGlobalStyles={true}` defers the `<style id="nextpress-global-styles">` block
- [ ] Lighthouse on a woographql.com page: "Eliminate render-blocking resources" no longer flags `nextpress-font-faces`