### PR TITLE
feat(global-styles): add skipFonts flag to suppress @font-face block

### DIFF
--- a/.changeset/skipfonts-globalstyles.md
+++ b/.changeset/skipfonts-globalstyles.md
@@ -1,0 +1,5 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+Add `skipFonts` boolean to `GlobalStyles` (forwarded by `WPHead`). When set, suppresses the `<style id="nextpress-font-faces">` block and its swap-script entirely — useful when the host application loads its own webfonts (e.g. via `next/font/google`) and doesn't want the WordPress-proxied `@font-face` declarations re-injected. Takes precedence over `deferFonts`.

--- a/docs/api/global-styles.md
+++ b/docs/api/global-styles.md
@@ -38,12 +38,37 @@ export default async function WordPressLayout({ children }) {
 | `pathname` | `string` | No | Current page pathname; used when resolving proxy URL placeholders in font-face rules |
 | `deferFonts` | `boolean` | No | Defer the `@font-face` block off the critical path. Default `true`. See [Deferring fonts](#deferring-fonts). |
 | `deferGlobalStyles` | `boolean` | No | Defer the theme.json `stylesheet` content. Default `false` — opt in only when you can absorb a token-flash on first paint. |
+| `skipFonts` | `boolean` | No | Skip the `@font-face` block entirely. Default `false`. Set when the host app loads its own webfonts (e.g. via [`next/font`](https://nextjs.org/docs/app/api-reference/components/font)) and doesn't want the WP-proxied font-face declarations re-injected. See [Skipping fonts](#skipping-fonts). |
 
 ## Deferring fonts
 
 By default `deferFonts: true` renders the `@font-face` `<style>` tag with `media="print" data-np-defer="1"` and emits a short inline script that swaps `media` to `"all"` once the rules are parsed. Lighthouse stops counting font-face declarations against "Eliminate render-blocking resources" without any visible regression — text above the fold paints with the system fallback (per `font-display: swap`) and re-paints with the web font as soon as it's downloaded, same as without the defer.
 
 Set `deferFonts={false}` if text above the fold uses glyphs that don't exist in any system fallback (icon fonts, custom symbol fonts), where rendering with the fallback would show `□` boxes instead of the intended character.
+
+## Skipping fonts
+
+`skipFonts: true` suppresses the `@font-face` `<style>` block entirely — no `<style id="nextpress-font-faces">` element, no swap-script. Use this when the host application already loads its own webfonts and doesn't need the WordPress-proxied declarations on the page. The canonical case is a Next.js app that loads matching families via [`next/font/google`](https://nextjs.org/docs/app/api-reference/components/font/google):
+
+```tsx
+import { Source_Serif_4, Onest } from 'next/font/google';
+
+const serif = Source_Serif_4({ subsets: ['latin'], variable: '--font-family-serif' });
+const sans  = Onest({ subsets: ['latin'], weight: ['400', '500', '600', '700'], variable: '--font-family-sans' });
+
+export default function Layout({ children }) {
+  return (
+    <html className={`${serif.variable} ${sans.variable}`}>
+      <head>
+        <WPHead globalStyles={globalStyles} skipFonts /* ...other props */ />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+`skipFonts` takes precedence over `deferFonts`: when both are set, the block is skipped (not just deferred). Theme.json `stylesheet` content and `customCss` are still rendered — `skipFonts` only scopes to the font-face block.
 
 ## Deferring globalStyles
 

--- a/docs/api/wp-head.md
+++ b/docs/api/wp-head.md
@@ -55,6 +55,7 @@ export default async function WordPressLayout({ children }) {
 | `criticalHandles` | `string[]` | No | Stylesheet handles to keep render-blocking; everything else is deferred via `media="print"` + swap-on-load. Forwarded to [`Stylesheets`](./stylesheets.md#critical-handles). Omit to keep all sheets blocking. |
 | `deferFonts` | `boolean` | No | Defer the theme.json `@font-face` block off the critical path. Default `true`. Forwarded to [`GlobalStyles`](./global-styles.md#deferring-fonts). |
 | `deferGlobalStyles` | `boolean` | No | Defer the theme.json `stylesheet` content. Default `false`. Forwarded to [`GlobalStyles`](./global-styles.md#deferring-globalstyles). |
+| `skipFonts` | `boolean` | No | Suppress the theme.json `@font-face` block entirely. Default `false`. Set when the host app loads its own webfonts (e.g. via `next/font`). Forwarded to [`GlobalStyles`](./global-styles.md#skipping-fonts). Takes precedence over `deferFonts`. |
 
 ## Render-blocking budget
 

--- a/packages/js/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/js/src/GlobalStyles/GlobalStyles.tsx
@@ -26,6 +26,15 @@ export interface GlobalStylesProps {
    * `deferFonts` to lift both off the critical path.
    */
   deferGlobalStyles?: boolean;
+  /**
+   * Skip the WP `@font-face` block entirely. Set to `true` when the
+   * host app is loading its own webfonts (e.g. via `next/font`) and
+   * doesn't want the WP-proxied font-face declarations re-injected.
+   * Suppresses the `<style id="nextpress-font-faces">` element and
+   * the swap-script that would have flipped its media attribute.
+   * Takes precedence over `deferFonts`.
+   */
+  skipFonts?: boolean;
 }
 
 // Type loophole: `style[media]` is a valid HTML attribute but
@@ -62,6 +71,7 @@ export function GlobalStyles({
   pathname = '',
   deferFonts = true,
   deferGlobalStyles = false,
+  skipFonts = false,
 }: GlobalStylesProps) {
   const { stylesheet, customCss, renderedFontFaces } = globalStyles;
 
@@ -69,7 +79,7 @@ export function GlobalStyles({
   // its own <style> wrapper. Strip it so we can render cleanly, then
   // replace any NextPress proxy placeholders so font URLs route through
   // the proxy instead of hitting WordPress directly.
-  const fontFaceCss = renderedFontFaces
+  const fontFaceCss = !skipFonts && renderedFontFaces
     ? replaceProxyPlaceholders(
         renderedFontFaces
           .replace(/<style[^>]*>/gi, '')

--- a/packages/js/src/WPHead/WPHead.tsx
+++ b/packages/js/src/WPHead/WPHead.tsx
@@ -34,13 +34,19 @@ export interface WPHeadProps {
    * flash on first paint. Forwarded to `GlobalStyles`.
    */
   deferGlobalStyles?: boolean;
+  /**
+   * Suppress the WP `@font-face` block — set when the host app
+   * loads its own webfonts (e.g. via `next/font`). Forwarded to
+   * `GlobalStyles`. Takes precedence over `deferFonts`.
+   */
+  skipFonts?: boolean;
 }
 
 /**
  * Server component that renders all WordPress head assets: global styles,
  * stylesheets, the script module import map, and header scripts.
  */
-export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance = 'default', pathname = '', criticalHandles, deferFonts, deferGlobalStyles }: WPHeadProps) {
+export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance = 'default', pathname = '', criticalHandles, deferFonts, deferGlobalStyles, skipFonts }: WPHeadProps) {
   return (
     <>
       {stylesheets && stylesheets.length > 0 && (
@@ -58,6 +64,7 @@ export function WPHead({ scripts, stylesheets, globalStyles, importMap, instance
           pathname={pathname}
           deferFonts={deferFonts}
           deferGlobalStyles={deferGlobalStyles}
+          skipFonts={skipFonts}
         />
       )}
       {importMap && importMap.length > 0 && (


### PR DESCRIPTION
## Summary

- Add `skipFonts` boolean to `GlobalStyles` (forwarded by `WPHead`). When set, the `<style id="nextpress-font-faces">` block and its swap-script are not rendered at all.
- For host apps loading their own webfonts (e.g. via `next/font/google`), the WP-proxied `@font-face` declarations are redundant — `deferFonts` only moves them off the critical path; `skipFonts` drops them entirely.
- Takes precedence over `deferFonts`. Docs updated in `docs/api/global-styles.md` and `docs/api/wp-head.md` with a `next/font` usage example.

## Test plan

- [ ] `skipFonts={true}` suppresses both the `<style id="nextpress-font-faces">` element and the defer-swap `<script>` (when no other deferred elements are present).
- [ ] `skipFonts` unset / `false` preserves the prior behavior — `deferFonts` still controls whether the block is print-deferred.
- [ ] `WPHead` forwards `skipFonts` to `GlobalStyles`.
- [ ] No change to `stylesheet` / `customCss` rendering when `skipFonts` is on.