### PR TITLE
feat(parsers): nextImageParser factory + toImageProps + render prop

### DIFF
--- a/.changeset/image-parser-factory.md
+++ b/.changeset/image-parser-factory.md
@@ -1,0 +1,11 @@
+---
+"@axistaylor/nextpress": minor
+---
+
+Refactor `nextImageParser` from a static parser const into a factory `nextImageParser({ instance?, render? })`. The factory resolves the WordPress instance config via `getWPInstance` / `getAllWPInstances` and routes same-host `<img>` src values through the existing wp-assets proxy by calling `resolveAssetHref` — so consumers no longer need to add their WordPress origin to `images.remotePatterns` in `next.config.js`. Cross-origin images still pass through unchanged.
+
+Adds a new `render` option that takes a component receiving `ImageProps`, defaulting to `next/image`'s `Image`. This is the recommended hook for centralizing app-wide image presentation (rounded corners, default `sizes`, placeholder strategy, etc.) without losing the proxy / attribute-conversion behaviour.
+
+Also exports `toImageProps(attrs, src)` — the pure conversion layer that turns a parsed `<img>`'s attribute map into a Next.js `ImageProps` object (handles `width`/`height` numeric coercion, `sizes`, `loading`, `fetchPriority` → `priority`, `crossOrigin`, `referrerPolicy`, `data-*` passthrough, plus `className` / `style` / `title` / `id`). Reusable when writing a custom parser that still wants the standard attribute mapping.
+
+**Breaking:** `nextImageParser` is no longer a parser itself — invocation is now required. Migrate `parsers={[nextImageParser]}` → `parsers={[nextImageParser()]}` (or `parsers={[nextImageParser({ instance: '<slug>' })]}` when not using the default single-instance setup).

--- a/docs/api/parsers.md
+++ b/docs/api/parsers.md
@@ -16,7 +16,7 @@ import { Content, nextImageParser } from '@axistaylor/nextpress';
 
 <Content
   content={wpContent}
-  parsers={[nextImageParser]}
+  parsers={[nextImageParser()]}
 />
 ```
 
@@ -25,7 +25,7 @@ Multiple parsers run in order:
 ```tsx
 <Content
   content={wpContent}
-  parsers={[nextImageParser, myCustomParser]}
+  parsers={[nextImageParser(), myCustomParser]}
 />
 ```
 
@@ -35,22 +35,72 @@ Multiple parsers run in order:
 
 **Import:** `import { nextImageParser } from '@axistaylor/nextpress'`
 
-Converts WordPress `<img>` tags to Next.js `<Image>` components for automatic WebP/AVIF optimization and responsive srcset generation.
+Factory that returns a parser converting WordPress `<img>` tags into Next.js `<Image>` components for automatic WebP/AVIF optimization and responsive srcset generation.
 
-- Passes intrinsic `width`/`height` for aspect ratio
-- Passes WordPress's `sizes` attribute for responsive srcset selection
-- Preserves `className`, `style`, and `data-*` attributes
-- Skips images without `width`/`height` (leaves them as native `<img>`)
+- Resolves the matching WordPress instance via [`getWPInstance`](#getwpinstanceslug) / [`getAllWPInstances`](#getallwpinstances) and rewrites same-host `<img>` src values through the NextPress asset proxy (`/atx/{slug}/wp-assets/...`). Consumers don't need to configure [`images.remotePatterns`](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns) for their WordPress origin.
+- Cross-origin images (CDNs, external embeds) pass through unchanged.
+- Converts WordPress `<img>` attributes into a Next.js `Image`-compatible prop shape via [`toImageProps`](#toimagepropsattrs-src) — `width`, `height`, `sizes`, `loading`, `fetchPriority` → `priority`, `crossOrigin`, `referrerPolicy`, `data-*`, plus pass-through of `className`, `style`, `title`, and `id`.
+- Skips images without `width`/`height` (leaves them as native `<img>`).
 
 ```tsx
 import { Content, nextImageParser } from '@axistaylor/nextpress';
 
 export default function Page({ content }) {
-  return <Content content={content} parsers={[nextImageParser]} />;
+  return <Content content={content} parsers={[nextImageParser({ instance: 'default' })]} />;
 }
 ```
 
-> **Note:** `nextImageParser` imports from `next/image` which is a client component, so it must be imported from `@axistaylor/nextpress/client`. Your Next.js config must include [`remotePatterns`](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns) for your WordPress domain.
+#### Options (`NextImageParserOptions`)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `instance` | `string` | `'default'` | The `withWCR` instance slug to resolve src URLs against. The matching instance's `wpHomeUrl` decides what's "same-host" (proxied) vs external (passed through). |
+| `render` | `ComponentType<ImageProps>` | `next/image`'s `Image` | Component the parser renders for each matched `<img>`. Receives the converted `ImageProps`. Use this to wrap or replace `<Image>` with your own component — e.g. one that applies app-wide image styling — without losing the proxy / prop-conversion behaviour. |
+
+#### Curating a parser with a custom render component
+
+The `render` prop is the recommended way to centralize image presentation. Anything the consumer wants every WP image to ship with — rounded corners, default `sizes`, a blur placeholder strategy, an overlay click handler, etc. — lives once on the wrapping component:
+
+```tsx
+import Image, { type ImageProps } from 'next/image';
+import { nextImageParser } from '@axistaylor/nextpress';
+
+function ArticleImage(props: ImageProps) {
+  return (
+    <Image
+      {...props}
+      className={`rounded-xl shadow-md ${props.className ?? ''}`}
+      sizes={props.sizes ?? '(min-width: 768px) 720px, 100vw'}
+    />
+  );
+}
+
+const articleImageParser = nextImageParser({
+  instance: 'default',
+  render: ArticleImage,
+});
+
+<Content content={post.content} parsers={[articleImageParser]} />
+```
+
+### `toImageProps(attrs, src)`
+
+**Import:** `import { toImageProps } from '@axistaylor/nextpress'`
+
+Pure helper that converts an `<img>` element's parsed `attributesToProps` output into a [`next/image` `ImageProps`](https://nextjs.org/docs/app/api-reference/components/image) object using the supplied `src`. Returns `null` when the attribute set is missing `width`/`height`. Re-use this if you're writing a fully custom image parser but still want the attribute-mapping behaviour the built-in parser provides.
+
+```ts
+import type { CustomParser } from '@axistaylor/nextpress';
+import { toImageProps } from '@axistaylor/nextpress';
+
+const myImageParser: CustomParser = (node, attrs) => {
+  if ((node as { name?: string }).name !== 'img') return undefined;
+  const src = (attrs as Record<string, unknown>).src as string;
+  const props = toImageProps(attrs, src);
+  if (!props) return undefined;
+  return <MyImage {...props} />;
+};
+```
 
 ### `createUrlRewritingParser`
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -8,5 +8,5 @@ export * from '@/WPHead';
 export * from '@/WPFooter';
 export * from '@/ImportMap';
 export { createUrlRewritingParser, type UrlRewritingParserOptions } from '@/parsers/urlRewritingParser';
-export { nextImageParser } from '@/parsers/nextImageParser';
+export { nextImageParser, toImageProps, type NextImageParserOptions } from '@/parsers/nextImageParser';
 export type { CustomParser, ElementProps } from '@/parsers/types';

--- a/packages/js/src/parsers/nextImageParser.tsx
+++ b/packages/js/src/parsers/nextImageParser.tsx
@@ -1,55 +1,70 @@
-import React from 'react';
-import Image from 'next/image';
+import React, { type ComponentType } from 'react';
+import Image, { type ImageProps } from 'next/image';
 import type { DOMNode } from 'html-react-parser';
 import type { CustomParser, ElementProps } from '@/parsers/types';
+import { resolveAssetHref } from '@/utils/url';
+import { getAllWPInstances, getWPInstance } from '@/config/getWPInstance';
 
-/**
- * Optional Content parser that converts WordPress <img> tags to Next.js
- * <Image> components for automatic image optimization (WebP/AVIF).
- *
- * Passes intrinsic width/height for aspect ratio and the WP sizes
- * attribute for responsive srcset selection. Images without width/height
- * are skipped (left as native <img>).
- */
-export const nextImageParser: CustomParser = (
-  node: DOMNode,
-  props: ElementProps,
-) => {
-  const el = node as unknown as { name?: string };
-  if (el.name !== 'img') return undefined;
+export interface NextImageParserOptions {
+  instance?: string;
+  render?: ComponentType<ImageProps>;
+}
 
-  const p = props as Record<string, unknown>;
-  const src = p.src as string;
-  if (!src) return undefined;
+export function toImageProps(attrs: ElementProps, src: string): ImageProps | null {
+  const p = attrs as Record<string, unknown>;
+  const width = parseInt(String(p.width ?? ''), 10) || 0;
+  const height = parseInt(String(p.height ?? ''), 10) || 0;
+  if (!width || !height) return null;
 
-  const alt = (p.alt as string) || '';
-  const className = (p.className as string) || undefined;
-  const style = p.style as React.CSSProperties | undefined;
-  const width = parseInt(String(p.width || ''), 10) || 0;
-  const height = parseInt(String(p.height || ''), 10) || 0;
-  const sizes = typeof p.sizes === 'string' ? p.sizes : undefined;
+  const out: ImageProps = {
+    src,
+    alt: typeof p.alt === 'string' ? p.alt : '',
+    width,
+    height,
+  };
 
-  // Skip images without intrinsic dimensions — can't optimize without them
-  if (!width || !height) return undefined;
+  if (typeof p.sizes === 'string') out.sizes = p.sizes;
+  if (typeof p.className === 'string') out.className = p.className;
+  if (typeof p.title === 'string') out.title = p.title;
+  if (typeof p.id === 'string') out.id = p.id;
+  if (p.style) out.style = p.style as React.CSSProperties;
+  if (p.loading === 'lazy' || p.loading === 'eager') out.loading = p.loading;
+  if (p.fetchPriority === 'high' || p.fetchpriority === 'high') out.priority = true;
+  if (typeof p.crossOrigin === 'string') out.crossOrigin = p.crossOrigin as ImageProps['crossOrigin'];
+  if (typeof p.referrerPolicy === 'string') out.referrerPolicy = p.referrerPolicy as ImageProps['referrerPolicy'];
 
-  // Collect data-* attributes
-  const dataAttrs: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(p)) {
     if (key.startsWith('data-')) {
-      dataAttrs[key] = value;
+      (out as Record<string, unknown>)[key] = value;
     }
   }
 
-  return (
-    <Image
-      src={src}
-      alt={alt}
-      width={width}
-      height={height}
-      sizes={sizes}
-      className={className}
-      style={style}
-      {...dataAttrs}
-    />
-  );
-};
+  return out;
+}
+
+export function nextImageParser({
+  instance = 'default',
+  render: Render = Image,
+}: NextImageParserOptions = {}): CustomParser {
+  const { wpHomeUrl } = getWPInstance(instance);
+  const otherInstances = Object.entries(getAllWPInstances())
+    .reduce((acc, [slug, entry]) => {
+      if (entry.wpHomeUrl === wpHomeUrl) return acc;
+      acc[slug] = entry.wpHomeUrl;
+      return acc;
+    }, {} as Record<string, string>);
+
+  return (node: DOMNode, props: ElementProps) => {
+    const el = node as unknown as { name?: string };
+    if (el.name !== 'img') return undefined;
+
+    const rawSrc = (props as Record<string, unknown>).src as string;
+    if (!rawSrc) return undefined;
+
+    const src = resolveAssetHref(rawSrc, instance, wpHomeUrl, otherInstances);
+    const imageProps = toImageProps(props, src);
+    if (!imageProps) return undefined;
+
+    return <Render {...imageProps} />;
+  };
+}

--- a/packages/nextjs-example/app/(wordpress-pages)/[...uri]/page.tsx
+++ b/packages/nextjs-example/app/(wordpress-pages)/[...uri]/page.tsx
@@ -37,7 +37,7 @@ export default async function Page({ params: paramsPromise }: PageParams) {
       content={data.content}
       contentCssClasses={data.contentCssClasses}
       linksAs={Link as unknown as FC<JSX.IntrinsicElements['a']>}
-      parsers={[nextImageParser]}
+      parsers={[nextImageParser()]}
     />
   );
 }


### PR DESCRIPTION
## Summary

- `nextImageParser` becomes a factory: `nextImageParser({ instance?, render? })`. Looks up the matching WordPress instance via `getWPInstance` / `getAllWPInstances` and routes same-host `<img>` src values through the existing wp-assets proxy by calling `resolveAssetHref`. Consumers no longer need to add their WordPress origin to `images.remotePatterns`. Cross-origin images pass through.
- New `render` option takes a component receiving `ImageProps`, defaulting to `next/image`'s `Image`. Recommended hook for centralizing app-wide image presentation without losing the proxy / attribute-conversion behaviour.
- Extract `toImageProps(attrs, src)` as a pure helper that maps WP `<img>` attributes → Next.js `ImageProps` (`width`/`height` numeric coercion, `sizes`, `loading`, `fetchPriority` → `priority`, `crossOrigin`, `referrerPolicy`, `data-*` passthrough, plus `className` / `style` / `title` / `id`). Re-exported so custom parsers can reuse the standard mapping.
- `packages/nextjs-example` updated to call the factory. Docs in `docs/api/parsers.md` rewritten to cover the factory shape + a curated-render example.
- **Breaking:** invocation now required — `parsers={[nextImageParser]}` → `parsers={[nextImageParser()]}`. Minor bump via changeset.

## Test plan

- [ ] `<Content parsers={[nextImageParser()]} />` proxies a WP-hosted `<img src="https://<wpHomeUrl>/app/uploads/.../foo.jpg">` to `/atx/default/wp-assets/app/uploads/.../foo.jpg` (the existing wp-assets handler).
- [ ] Same call leaves a cross-origin `<img src="https://cdn.example.com/foo.jpg">` untouched.
- [ ] Passing `render` swaps the rendered component while keeping the resolved src + converted props intact.
- [ ] `toImageProps` returns `null` when width/height are missing and a fully-formed `ImageProps` otherwise.
- [ ] `nextjs-example` builds + renders WP content with the updated factory call.