### PR TITLE
feat(AssetUpdater): resolve __NEXTPRESS_* placeholders in attribute values on DOM mutation

### DIFF
--- a/.changeset/asset-updater-placeholder-observer.md
+++ b/.changeset/asset-updater-placeholder-observer.md
@@ -1,0 +1,5 @@
+---
+"@axistaylor/nextpress": patch
+---
+
+`AssetUpdater` now runs a `MutationObserver` that resolves `__NEXTPRESS_*` placeholders found in element attribute values everywhere in the document — covering both the initial server-rendered tree and any DOM that gets inserted or attribute-mutated after mount. Scoped to attribute values only (text content and characterData mutations are not processed) and short-circuits on a substring guard before touching the regex path, so per-mutation overhead is small. Disconnects cleanly on unmount or when `instance` / `pathname` change.

--- a/packages/js/src/AssetUpdater/AssetUpdater.tsx
+++ b/packages/js/src/AssetUpdater/AssetUpdater.tsx
@@ -6,6 +6,7 @@ import { transformAssetUrl, isBypassedHost } from '@/utils/url';
 import { firePageEvents } from '@/hooks/usePageEvents';
 import { joinScriptContent } from '@/utils/content';
 import { replaceProxyPlaceholders, processWcSettings } from '@/compatibility/woocommerce';
+import { startPlaceholderObserver } from './placeholderObserver';
 
 export interface AssetData {
   stylesheets: EnqueuedStylesheet[];
@@ -432,6 +433,14 @@ export function AssetUpdater({
   fetchAssets,
   bypassDomains = [],
 }: AssetUpdaterProps) {
+  // Watch the DOM for `__NEXTPRESS_*` placeholders in element attribute
+  // values and rewrite them to proxy values on every mutation. Lives in
+  // its own effect so a navigation that re-runs the asset-fetch effect
+  // below doesn't tear down the observer mid-flight.
+  useEffect(() => {
+    return startPlaceholderObserver(instance, pathname);
+  }, [instance, pathname]);
+
   // Skip only the initial mount — the server already rendered those assets.
   // Every effect run after the first one (including returning to the initial
   // pathname) re-fetches and re-applies assets.

--- a/packages/js/src/AssetUpdater/placeholderObserver.ts
+++ b/packages/js/src/AssetUpdater/placeholderObserver.ts
@@ -1,0 +1,94 @@
+import { replaceProxyPlaceholders } from '@/compatibility/woocommerce';
+
+const PLACEHOLDER = '__NEXTPRESS_';
+
+/**
+ * Replace `__NEXTPRESS_*` placeholders found in any of the element's
+ * attribute values with their resolved proxy values. Skips text content
+ * and the element's children — call the observer to handle subtrees.
+ */
+function processElementAttributes(
+  el: Element,
+  instance: string,
+  pathname: string,
+): void {
+  const { attributes } = el;
+  for (let i = 0; i < attributes.length; i += 1) {
+    const attr = attributes[i];
+    const value = attr.value;
+    if (!value || value.indexOf(PLACEHOLDER) === -1) continue;
+    const replaced = replaceProxyPlaceholders(value, instance, pathname);
+    if (replaced !== value) {
+      el.setAttribute(attr.name, replaced);
+    }
+  }
+}
+
+/**
+ * Walk an element and every element descendant, applying
+ * `processElementAttributes` to each.
+ */
+function processSubtree(root: Element, instance: string, pathname: string): void {
+  processElementAttributes(root, instance, pathname);
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  let node: Node | null = walker.nextNode();
+  while (node) {
+    processElementAttributes(node as Element, instance, pathname);
+    node = walker.nextNode();
+  }
+}
+
+/**
+ * Start a MutationObserver that resolves `__NEXTPRESS_*` placeholders
+ * found in element attribute values everywhere in the document. Runs
+ * one initial sweep over the existing tree, then watches:
+ *
+ *   - `attributes` mutations — covers in-place updates to a single
+ *     attribute on an existing element.
+ *   - `childList` mutations with `subtree: true` — covers new elements
+ *     inserted anywhere (each new element + its descendants get swept).
+ *
+ * Text node content and characterData mutations are NOT processed —
+ * only element attributes.
+ *
+ * Returns a disconnect function that the caller invokes on cleanup.
+ */
+export function startPlaceholderObserver(
+  instance: string,
+  pathname: string,
+): () => void {
+  processSubtree(document.documentElement, instance, pathname);
+
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      if (record.type === 'attributes' && record.target.nodeType === Node.ELEMENT_NODE) {
+        const attrName = record.attributeName;
+        const el = record.target as Element;
+        if (!attrName) continue;
+        const value = el.getAttribute(attrName);
+        if (!value || value.indexOf(PLACEHOLDER) === -1) continue;
+        const replaced = replaceProxyPlaceholders(value, instance, pathname);
+        if (replaced !== value) {
+          el.setAttribute(attrName, replaced);
+        }
+        continue;
+      }
+      if (record.type === 'childList') {
+        for (let i = 0; i < record.addedNodes.length; i += 1) {
+          const added = record.addedNodes[i];
+          if (added.nodeType === Node.ELEMENT_NODE) {
+            processSubtree(added as Element, instance, pathname);
+          }
+        }
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    attributes: true,
+    subtree: true,
+  });
+
+  return () => observer.disconnect();
+}


### PR DESCRIPTION
## Summary

- `AssetUpdater` runs a `MutationObserver` on `document.documentElement` that resolves `__NEXTPRESS_PROXY__` / `__NEXTPRESS_ASSETS__` placeholders found in element attribute values everywhere in the document.
- One initial sweep over the SSR'd tree on mount, then per-mutation rewrites for `attributes` and `childList` mutations (with `subtree: true`).
- Scoped to element attributes only — text content and characterData mutations are intentionally not processed.
- Substring guard short-circuits before the regex path, so per-mutation overhead stays low on attributes without the placeholder.
- Observer disconnects cleanly on unmount or when `instance` / `pathname` change.

## Test plan

- [ ] Render an SSR'd page that includes element attributes with `__NEXTPRESS_ASSETS__` / `__NEXTPRESS_PROXY__` placeholders → verify they're rewritten to the resolved proxy URLs on first paint.
- [ ] After mount, inject a new element via `document.body.appendChild` whose attributes contain `__NEXTPRESS_*` → verify the placeholders are rewritten without re-rendering.
- [ ] Mutate an existing attribute via `el.setAttribute('href', 'http://__NEXTPRESS_PROXY__/cart')` → verify the value resolves.
- [ ] Navigate between two pages (different `pathname`) → verify the observer restarts cleanly without leaking listeners.
- [ ] Text content containing the placeholder string is NOT rewritten (out of scope by design).